### PR TITLE
Add helm3 chart for StorageOS v2.1.0

### DIFF
--- a/charts/storageos-operator/v2.1.0/Chart.yaml
+++ b/charts/storageos-operator/v2.1.0/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+appVersion: "v2.1.0"
+description: Cloud Native storage for containers
+name: storageos-operator
+version: 0.4.0
+keywords:
+- storage
+- block-storage
+- volume
+- operator
+home: https://storageos.com
+icon: https://docs.storageos.com/images/logo-helm.svg
+sources:
+- https://github.com/storageos
+maintainers:
+- name: croomes
+  email: simon.croome@storageos.com
+- name: darkowlzz
+  email: sunny.gogoi@storageos.com

--- a/charts/storageos-operator/v2.1.0/LICENSE
+++ b/charts/storageos-operator/v2.1.0/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 StorageOS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/charts/storageos-operator/v2.1.0/README.md
+++ b/charts/storageos-operator/v2.1.0/README.md
@@ -1,0 +1,242 @@
+# StorageOS Operator Helm Chart
+
+> **Note**: This chart requires Helm 3 and defaults to StorageOS v2. To upgrade
+> from a previous chart or from StorageOS version 1.x to 2.x, please contact
+> support for assistance.
+
+[StorageOS](https://storageos.com) is a software-based storage platform
+designed for cloud-native applications. By deploying StorageOS on your
+Kubernetes cluster, local storage from cluster node is aggregated into a
+distributed pool, and persistent volumes created from it using the native
+Kubernetes volume driver are available instantly to pods wherever they move in
+the cluster.
+
+Features such as replication, encryption and caching help protect data and
+maximise performance.
+
+This chart installs a StorageOS Cluster Operator which helps deploy and
+configure a StorageOS cluster on kubernetes.
+
+## Prerequisites
+
+- Helm 3
+- Kubernetes 1.13+
+- Privileged mode containers (enabled by default)
+- Etcd cluster
+
+Refer to the [StorageOS prerequisites
+docs](https://docs.storageos.com/docs/prerequisites/) for more information.
+
+## Installing the chart
+
+```console
+# Add storageos charts repo.
+$ helm repo add storageos https://charts.storageos.com
+# Install the chart in a namespace.
+$ kubectl create namespace storageos-operator
+$ helm install my-storageos storageos/storageos-operator \
+    --namespace storageos-operator \
+    --set cluster.kvBackend.address=<etcd-node-ip>:2379 \
+    --set cluster.admin.password=<password>
+```
+
+This will install the StorageOS cluster operator in `storageos-operator`
+namespace and deploys StorageOS with a minimal configuration. Etcd address
+(kvBackend) and admin password are mandatory values to install the chart. To
+avoid passing the password as a flag, create a values.yaml file and pass the
+file name with `--values` flag.
+
+```yaml
+cluster:
+  kvBackend:
+    address: <etcd-node-ip>:2379
+  admin:
+    password: <password>
+```
+
+The password must be at least 8 characters long and the default username is
+`storageos`, which can be changed like the above values. Find more information
+about installing etcd in our [etcd
+docs](https://docs.storageos.com/docs/prerequisites/etcd/).
+
+Install the chart with the values file:
+
+```console
+$ helm install my-storageos storageos/storageos-operator \
+    --namespace storageos-operator \
+    --values <values-file>
+```
+
+> **Tip**: List all releases using `helm list -A`
+
+## Creating a StorageOS cluster manually
+
+The Helm chart supports a subset of StorageOSCluster custom resource parameters.
+For advanced configurations, you may wish to create the cluster resource
+manually and only use the Helm chart to install the Operator.
+
+To disable auto-provisioning the cluster with the Helm chart, set
+`cluster.create` to false:
+
+```yaml
+cluster:
+  ...
+  create: false
+```
+
+Create a secret to store storageos cluster secrets:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "storageos-api"
+  namespace: "storageos-operator"
+  labels:
+    app: "storageos"
+type: "kubernetes.io/storageos"
+data:
+  # echo -n '<secret>' | base64
+  apiUsername: c3RvcmFnZW9z
+  apiPassword: c3RvcmFnZW9z
+  csiProvisionUsername: c3RvcmFnZW9z
+  csiProvisionPassword: c3RvcmFnZW9z
+  csiControllerPublishUsername: c3RvcmFnZW9z
+  csiControllerPublishPassword: c3RvcmFnZW9z
+  csiNodePublishUsername: c3RvcmFnZW9z
+  csiNodePublishPassword: c3RvcmFnZW9z
+  csiControllerExpandUsername: c3RvcmFnZW9z
+  csiControllerExpandPassword: c3RvcmFnZW9z
+```
+
+Create a `StorageOSCluster` custom resource and refer the above secret in
+`secretRefName` and `secretRefNamespace` fields.
+
+```yaml
+apiVersion: "storageos.com/v1"
+kind: "StorageOSCluster"
+metadata:
+  name: "example-storageos"
+  namespace: "default"
+spec:
+  secretRefName: "storageos-api"
+  secretRefNamespace: "default"
+  csi:
+    enable: true
+    deploymentStrategy: "deployment"
+    enableProvisionCreds: true
+    enableControllerPublishCreds: true
+    enableNodePublishCreds: true
+  kvBackend:
+    address: "etcd-client.etcd.svc.cluster.local:2379"
+    # address: '10.42.15.23:2379,10.42.12.22:2379,10.42.13.16:2379' # You can set ETCD server IPs.
+```
+
+Once the `StorageOSCluster` configuration is applied, the StorageOSCluster
+operator will create a StorageOS cluster in the `kube-system` namespace by
+default. Installing into the kube-system namespace is recommended so that the
+storage containers can be marked as system-node-critical. This reduces the risk
+that the storage containers get evicted before applications that require the
+storage they provide.
+
+Learn more about advanced configuration options
+[here](https://github.com/storageos/cluster-operator/blob/master/README.md#storageoscluster-resource-configuration).
+
+To check cluster status, run:
+
+```console
+$ kubectl get storageoscluster --namespace storageos-operator
+NAME                READY     STATUS    AGE
+example-storageos   3/3       Running   4m
+```
+
+All the events related to this cluster are logged as part of the cluster object
+and can be viewed by describing the object.
+
+```console
+$ kubectl describe storageoscluster example-storageos
+Name:         example-storageos
+Namespace:    default
+Labels:       <none>
+...
+...
+Events:
+  Type     Reason         Age              From                       Message
+  ----     ------         ----             ----                       -------
+  Warning  ChangedStatus  1m (x2 over 1m)  storageos-operator  0/3 StorageOS nodes are functional
+  Normal   ChangedStatus  35s              storageos-operator  3/3 StorageOS nodes are functional. Cluster healthy
+```
+
+## Configuration
+
+The following tables lists the configurable parameters of the StorageOSCluster
+Operator chart and their default values.
+
+Parameter | Description | Default
+--------- | ----------- | -------
+`operator.image.repository` | StorageOS Operator container image repository | `storageos/cluster-operator`
+`operator.image.tag` | StorageOS Operator container image tag | `v2.1.0`
+`operator.image.pullPolicy` | StorageOS Operator container image pull policy | `IfNotPresent`
+`podSecurityPolicy.enabled` | If true, create & use PodSecurityPolicy resources | `false`
+`podSecurityPolicy.annotations` | Specify pod annotations in the pod security policy | `{}`
+`cluster.create` | If true, auto-create the StorageOS cluster | `true`
+`cluster.name` | Name of the storageos deployment | `storageos`
+`cluster.namespace` | Namespace to install the StorageOS cluster into | `kube-system`
+`cluster.secretRefName` | Name of the secret containing StorageOS API credentials | `storageos-api`
+`cluster.admin.username` | Username to authenticate to the StorageOS API with | `storageos`
+`cluster.admin.password` | Password to authenticate to the StorageOS API with |
+`cluster.sharedDir` | The path shared into to kubelet container when running kubelet in a container |
+`cluster.kvBackend.address` | List of etcd targets, in the form ip[:port], separated by commas |
+`cluster.kvBackend.backend` | Key-Value store backend name | `etcd`
+`cluster.kvBackend.tlsSecretName` | Name of the secret containing kv backend tls cert |
+`cluster.kvBackend.tlsSecretNamespace` | Namespace of the secret containing kv backend tls cert |
+`cluster.nodeSelectorTerm.key` | Key of the node selector term used for pod placement |
+`cluster.nodeSelectorTerm.value` | Value of the node selector term used for pod placement |
+`cluster.toleration.key` | Key of the pod toleration parameter |
+`cluster.toleration.value` | Value of the pod toleration parameter |
+`cluster.disableTelemetry` | If true, no telemetry data will be collected from the cluster | `false`
+`cluster.images.node.repository` | StorageOS Node container image repository |
+`cluster.images.node.tag` | StorageOS Node container image tag |
+`cluster.images.init.repository` | StorageOS init container image repository |
+`cluster.images.init.tag` | StorageOS init container image tag |
+`cluster.images.csiV1ClusterDriverRegistrar.repository` | CSI v1 Cluster Driver Registrar image repository |
+`cluster.images.csiV1ClusterDriverRegistrar.tag` | CSI v1 Cluster Driver Registrar image tag |
+`cluster.images.csiV1NodeDriverRegistrar.repository` | CSI v1 Node Driver Registrar image repository |
+`cluster.images.csiV1NodeDriverRegistrar.tag` | CSI v1 Node Driver Registrar image tag |
+`cluster.images.csiV1ExternalProvisioner.repository` | CSI v1 External Provisioner image repository |
+`cluster.images.csiV1ExternalProvisioner.tag` | CSI v1 External Provisioner image tag |
+`cluster.images.csiV1ExternalAttacher.repository` | CSI v1 External Attacher image repository |
+`cluster.images.csiV1ExternalAttacher.tag` | CSI v1 External Attacher image tag |
+`cluster.images.csiV1ExternalAttacherV2.repository` | CSI v1 External Attacher v2 image repository |
+`cluster.images.csiV1ExternalAttacherV2.tag` | CSI v1 External Attacher v2 image tag |
+`cluster.images.csiV1LivenessProbe.repository` | CSI v1 Liveness Probe image repository |
+`cluster.images.csiV1LivenessProbe.tag` | CSI v1 Liveness Probe image tag |
+`cluster.images.csiV1ExternalResizer.repository` | CSI v1 External Resizer image repository |
+`cluster.images.csiV1ExternalResizer.tag` | CSI v1 External Resizer image tag |
+
+## Deleting a StorageOS Cluster
+
+Deleting the `StorageOSCluster` custom resource object would delete the
+storageos cluster and all the associated resources.
+
+In the above example,
+
+```console
+$ kubectl delete storageoscluster example-storageos
+```
+
+would delete the custom resource and the cluster.
+
+## Uninstalling the Chart
+
+To uninstall/delete the storageos cluster operator deployment:
+
+```console
+$ helm uninstall <release-name> --namespace storageos-operator
+```
+
+If the chart was installed with cluster auto-provisioning enabled, chart
+uninstall will clean-up the installed StorageOS cluster resources as well.
+
+Learn more about configuring the StorageOS Operator on
+[GitHub](https://github.com/storageos/cluster-operator).

--- a/charts/storageos-operator/v2.1.0/app-readme.md
+++ b/charts/storageos-operator/v2.1.0/app-readme.md
@@ -1,0 +1,32 @@
+# StorageOS Operator
+
+[StorageOS](https://storageos.com) is a cloud native, software-defined storage
+platform that transforms commodity server or cloud based disk capacity into
+enterprise-class persistent storage for containers. StorageOS is ideal for
+deploying databases, message queues, and other mission-critical stateful
+solutions, where rapid recovery and fault tolerance are essential.
+
+The StorageOS Operator installs and manages StorageOS within a cluster.
+Cluster nodes may contribute local or attached disk-based storage into a
+distributed pool, which is then available to all cluster members via a
+global namespace.
+
+StorageOS requires an etcd cluster in order to function. Find out more about
+setting up an etcd cluster in our [etcd
+docs](https://docs.storageos.com/docs/prerequisites/etcd/).
+
+By default, a minimal configuration of StorageOS is installed. To set advanced
+configurations, disable the default installation of StorageOS and create a
+custom StorageOSCluster resource
+([documentation](https://docs.storageos.com/docs/reference/cluster-operator/examples)).
+
+Newly installed StorageOS clusters require a license to function. For
+instructions on applying our free developer license, or obtaining a commercial
+license, please see our documentation at
+https://docs.storageos.com/docs/reference/licence/.
+
+> **Notes**:
+> - The StorageOS Operator must be installed in the System Project with Cluster
+> Role.
+> - To upgrade from StorageOS version 1.x to 2.x, please contact support
+> for assistance.

--- a/charts/storageos-operator/v2.1.0/ci/std-values.yaml
+++ b/charts/storageos-operator/v2.1.0/ci/std-values.yaml
@@ -1,0 +1,5 @@
+podSecurityPolicy:
+  enabled: true
+cluster:
+  # Disable cluster creation in CI, should install the operator only.
+  create: false

--- a/charts/storageos-operator/v2.1.0/crds/job_crd.yaml
+++ b/charts/storageos-operator/v2.1.0/crds/job_crd.yaml
@@ -1,0 +1,85 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: jobs.storageos.com
+spec:
+  group: storageos.com
+  names:
+    kind: Job
+    listKind: JobList
+    plural: jobs
+    singular: job
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            args:
+              description: Args is an array of strings passed as an argument to the
+                job container.
+              items:
+                type: string
+              type: array
+            completionWord:
+              description: CompletionWord is the word that's looked for in the pod
+                logs to find out if a DaemonSet Pod has completed its task.
+              type: string
+            hostPath:
+              description: HostPath is the path in the host that's mounted into a
+                job container.
+              type: string
+            image:
+              description: Image is the container image to run as the job.
+              type: string
+            labelSelector:
+              description: LabelSelector is the label selector for the job Pods.
+              type: string
+            mountPath:
+              description: MountPath is the path in the job container where a volume
+                is mounted.
+              type: string
+            nodeSelectorTerms:
+              description: NodeSelectorTerms is the set of placement of the job pods
+                using node affinity requiredDuringSchedulingIgnoredDuringExecution.
+              items:
+                type: object
+              type: array
+            tolerations:
+              description: Tolerations is to set the placement of storageos pods using
+                pod toleration.
+              items:
+                type: object
+              type: array
+          required:
+          - image
+          - args
+          - mountPath
+          - hostPath
+          - completionWord
+          type: object
+        status:
+          properties:
+            completed:
+              description: Completed indicates the complete status of job.
+              type: boolean
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/storageos-operator/v2.1.0/crds/nfsserver_crd.yaml
+++ b/charts/storageos-operator/v2.1.0/crds/nfsserver_crd.yaml
@@ -1,0 +1,153 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: nfsservers.storageos.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: Status of the NFS server.
+    name: status
+    type: string
+  - JSONPath: .spec.resources.requests.storage
+    description: Capacity of the NFS server.
+    name: capacity
+    type: string
+  - JSONPath: .status.remoteTarget
+    description: Remote target address of the NFS server.
+    name: target
+    type: string
+  - JSONPath: .status.accessModes
+    description: Access modes supported by the NFS server.
+    name: access modes
+    type: string
+  - JSONPath: .spec.storageClassName
+    description: StorageClass used for creating the NFS volume.
+    name: storageclass
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
+  group: storageos.com
+  names:
+    kind: NFSServer
+    listKind: NFSServerList
+    plural: nfsservers
+    shortNames:
+    - nfsserver
+    singular: nfsserver
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            annotations:
+              additionalProperties:
+                type: string
+              description: The annotations-related configuration to add/set on each
+                Pod related object.
+              type: object
+            export:
+              description: The parameters to configure the NFS export
+              properties:
+                name:
+                  description: Name of the export
+                  type: string
+                persistentVolumeClaim:
+                  description: PVC from which the NFS daemon gets storage for sharing
+                  type: object
+                server:
+                  description: The NFS server configuration
+                  properties:
+                    accessMode:
+                      description: Reading and Writing permissions on the export Valid
+                        values are "ReadOnly", "ReadWrite" and "none"
+                      type: string
+                    squash:
+                      description: This prevents the root users connected remotely
+                        from having root privileges Valid values are "none", "rootid",
+                        "root", and "all"
+                      type: string
+                  type: object
+              type: object
+            mountOptions:
+              description: PV mount options. Not validated - mount of the PVs will
+                simply fail if one is invalid.
+              items:
+                type: string
+              type: array
+            nfsContainer:
+              description: NFSContainer is the container image to use for the NFS
+                server.
+              type: string
+            persistentVolumeClaim:
+              description: PersistentVolumeClaim is the PVC source of the PVC to be
+                used with the NFS Server. If not specified, a new PVC is provisioned
+                and used.
+              type: object
+            persistentVolumeReclaimPolicy:
+              description: Reclamation policy for the persistent volume shared to
+                the user's pod.
+              type: string
+            resources:
+              description: Resources represents the minimum resources required
+              type: object
+            storageClassName:
+              description: StorageClassName is the name of the StorageClass used by
+                the NFS volume.
+              type: string
+            tolerations:
+              description: Tolerations is to set the placement of NFS server pods
+                using pod toleration.
+              items:
+                type: object
+              type: array
+          type: object
+        status:
+          properties:
+            accessModes:
+              description: AccessModes is the access modes supported by the NFS server.
+              type: string
+            phase:
+              description: 'Phase is a simple, high-level summary of where the NFS
+                Server is in its lifecycle. Phase will be set to Ready when the NFS
+                Server is ready for use.  It is intended to be similar to the PodStatus
+                Phase described at: https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.14/#podstatus-v1-core  There
+                are five possible phase values:   - Pending: The NFS Server has been
+                accepted by the Kubernetes system,     but one or more of the components
+                has not been created. This includes     time before being scheduled
+                as well as time spent downloading images     over the network, which
+                could take a while.   - Running: The NFS Server has been bound to
+                a node, and all of the     dependencies have been created.   - Succeeded:
+                All NFS Server dependencies have terminated in success,     and will
+                not be restarted.   - Failed: All NFS Server dependencies in the pod
+                have terminated, and     at least one container has terminated in
+                failure. The container     either exited with non-zero status or was
+                terminated by the system.   - Unknown: For some reason the state of
+                the NFS Server could not be     obtained, typically due to an error
+                in communicating with the host of     the pod.'
+              type: string
+            remoteTarget:
+              description: RemoteTarget is the connection string that clients can
+                use to access the shared filesystem.
+              type: string
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/storageos-operator/v2.1.0/crds/storageoscluster_crd.yaml
+++ b/charts/storageos-operator/v2.1.0/crds/storageoscluster_crd.yaml
@@ -1,0 +1,311 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: storageosclusters.storageos.com
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.ready
+    description: Ready status of the storageos nodes.
+    name: ready
+    type: string
+  - JSONPath: .status.phase
+    description: Status of the whole cluster.
+    name: status
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: age
+    type: date
+  group: storageos.com
+  names:
+    kind: StorageOSCluster
+    listKind: StorageOSClusterList
+    plural: storageosclusters
+    shortNames:
+    - stos
+    singular: storageoscluster
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            csi:
+              description: CSI defines the configurations for CSI.
+              properties:
+                deploymentStrategy:
+                  type: string
+                deviceDir:
+                  type: string
+                driverRegisterationMode:
+                  type: string
+                driverRequiresAttachment:
+                  type: string
+                enable:
+                  type: boolean
+                enableControllerExpandCreds:
+                  type: boolean
+                enableControllerPublishCreds:
+                  type: boolean
+                enableNodePublishCreds:
+                  type: boolean
+                enableProvisionCreds:
+                  type: boolean
+                endpoint:
+                  type: string
+                kubeletDir:
+                  type: string
+                kubeletRegistrationPath:
+                  type: string
+                pluginDir:
+                  type: string
+                registrarSocketDir:
+                  type: string
+                registrationDir:
+                  type: string
+                version:
+                  type: string
+              type: object
+            debug:
+              description: Debug is to set debug mode of the cluster.
+              type: boolean
+            disableFencing:
+              description: 'Disable Pod Fencing.  With StatefulSets, Pods are only
+                re-scheduled if the Pod has been marked as killed.  In practice this
+                means that failover of a StatefulSet pod is a manual operation.  By
+                enabling Pod Fencing and setting the `storageos.com/fenced=true` label
+                on a Pod, StorageOS will enable automated Pod failover (by killing
+                the application Pod on the failed node) if the following conditions
+                exist:  - Pod fencing has not been explicitly disabled. - StorageOS
+                has determined that the node the Pod is running on is   offline.  StorageOS
+                uses Gossip and TCP checks and will retry for 30   seconds.  At this
+                point all volumes on the failed node are marked   offline (irrespective
+                of whether fencing is enabled) and volume   failover starts. - The
+                Pod has the label `storageos.com/fenced=true` set. - The Pod has at
+                least one StorageOS volume attached. - Each StorageOS volume has at
+                least 1 healthy replica.  When Pod Fencing is disabled, StorageOS
+                will not perform any interaction with Kubernetes when it detects that
+                a node has gone offline. Additionally, the Kubernetes permissions
+                required for Fencing will not be added to the StorageOS role.'
+              type: boolean
+            disableScheduler:
+              description: Disable StorageOS scheduler extender.
+              type: boolean
+            disableTCMU:
+              description: Disable TCMU can be set to true to disable the TCMU storage
+                driver.  This is required when there are multiple storage systems
+                running on the same node and you wish to avoid conflicts.  Only one
+                TCMU-based storage system can run on a node at a time.  Disabling
+                TCMU will degrade performance.
+              type: boolean
+            disableTelemetry:
+              description: Disable Telemetry.
+              type: boolean
+            forceTCMU:
+              description: Force TCMU can be set to true to ensure that TCMU is enabled
+                or cause StorageOS to abort startup.  At startup, StorageOS will automatically
+                fallback to non-TCMU mode if another TCMU-based storage system is
+                running on the node.  Since non-TCMU will degrade performance, this
+                may not always be desired.
+              type: boolean
+            images:
+              description: Images defines the various container images used in the
+                cluster.
+              properties:
+                csiClusterDriverRegistrarContainer:
+                  type: string
+                csiExternalAttacherContainer:
+                  type: string
+                csiExternalProvisionerContainer:
+                  type: string
+                csiExternalResizerContainer:
+                  type: string
+                csiLivenessProbeContainer:
+                  type: string
+                csiNodeDriverRegistrarContainer:
+                  type: string
+                hyperkubeContainer:
+                  type: string
+                initContainer:
+                  type: string
+                kubeSchedulerContainer:
+                  type: string
+                nfsContainer:
+                  type: string
+                nodeContainer:
+                  type: string
+              type: object
+            ingress:
+              description: Ingress defines the ingress configurations used in the
+                cluster.
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                enable:
+                  type: boolean
+                hostname:
+                  type: string
+                tls:
+                  type: boolean
+              type: object
+            join:
+              description: Join is the join token used for service discovery.
+              type: string
+            k8sDistro:
+              description: 'K8sDistro is the name of the Kubernetes distribution where
+                the operator is being deployed.  It should be in the format: `name[-1.0]`,
+                where the version is optional and should only be appended if known.  Suitable
+                names include: `openshift`, `rancher`, `aks`, `gke`, `eks`, or the
+                deployment method if using upstream directly, e.g `minishift` or `kubeadm`.  Setting
+                k8sDistro is optional, and will be used to simplify cluster configuration
+                by setting appropriate defaults for the distribution.  The distribution
+                information will also be included in the product telemetry (if enabled),
+                to help focus development efforts.'
+              type: string
+            kvBackend:
+              description: KVBackend defines the key-value store backend used in the
+                cluster.
+              properties:
+                address:
+                  type: string
+                backend:
+                  type: string
+              type: object
+            namespace:
+              description: Namespace is the kubernetes Namespace where storageos resources
+                are provisioned.
+              type: string
+            nodeSelectorTerms:
+              description: NodeSelectorTerms is to set the placement of storageos
+                pods using node affinity requiredDuringSchedulingIgnoredDuringExecution.
+              items:
+                type: object
+              type: array
+            pause:
+              description: Pause is to pause the operator for the cluster.
+              type: boolean
+            resources:
+              description: Resources is to set the resource requirements of the storageos
+                containers.
+              type: object
+            secretRefName:
+              description: SecretRefName is the name of the secret object that contains
+                all the sensitive cluster configurations.
+              type: string
+            secretRefNamespace:
+              description: SecretRefNamespace is the namespace of the secret reference.
+              type: string
+            service:
+              description: Service is the Service configuration for the cluster nodes.
+              properties:
+                annotations:
+                  additionalProperties:
+                    type: string
+                  type: object
+                externalPort:
+                  format: int64
+                  type: integer
+                internalPort:
+                  format: int64
+                  type: integer
+                name:
+                  type: string
+                type:
+                  type: string
+              required:
+              - name
+              - type
+              type: object
+            sharedDir:
+              description: 'SharedDir is the shared directory to be used when the
+                kubelet is running in a container. Typically: "/var/lib/kubelet/plugins/kubernetes.io~storageos".
+                If not set, defaults will be used.'
+              type: string
+            storageClassName:
+              description: StorageClassName is the name of default StorageClass created
+                for StorageOS volumes.
+              type: string
+            tlsEtcdSecretRefName:
+              description: TLSEtcdSecretRefName is the name of the secret object that
+                contains the etcd TLS certs. This secret is shared with etcd, therefore
+                it's not part of the main storageos secret.
+              type: string
+            tlsEtcdSecretRefNamespace:
+              description: TLSEtcdSecretRefNamespace is the namespace of the etcd
+                TLS secret object.
+              type: string
+            tolerations:
+              description: Tolerations is to set the placement of storageos pods using
+                pod toleration.
+              items:
+                type: object
+              type: array
+          required:
+          - secretRefName
+          - secretRefNamespace
+          type: object
+        status:
+          properties:
+            members:
+              properties:
+                ready:
+                  description: Ready are the storageos cluster members that are ready
+                    to serve requests. The member names are the same as the node IPs.
+                  items:
+                    type: string
+                  type: array
+                unready:
+                  description: Unready are the storageos cluster nodes not ready to
+                    serve requests.
+                  items:
+                    type: string
+                  type: array
+              type: object
+            nodeHealthStatus:
+              additionalProperties:
+                properties:
+                  directfsInitiator:
+                    type: string
+                  director:
+                    type: string
+                  kv:
+                    type: string
+                  kvWrite:
+                    type: string
+                  nats:
+                    type: string
+                  presentation:
+                    type: string
+                  rdb:
+                    type: string
+                type: object
+              type: object
+            nodes:
+              items:
+                type: string
+              type: array
+            phase:
+              type: string
+            ready:
+              type: string
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/storageos-operator/v2.1.0/crds/storageosupgrade_crd.yaml
+++ b/charts/storageos-operator/v2.1.0/crds/storageosupgrade_crd.yaml
@@ -1,0 +1,48 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: storageosupgrades.storageos.com
+spec:
+  group: storageos.com
+  names:
+    kind: StorageOSUpgrade
+    listKind: StorageOSUpgradeList
+    plural: storageosupgrades
+    singular: storageosupgrade
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            newImage:
+              description: NewImage is the new StorageOS node container image.
+              type: string
+          required:
+          - newImage
+          type: object
+        status:
+          properties:
+            completed:
+              description: Completed is the status of upgrade process.
+              type: boolean
+          type: object
+  version: v1
+  versions:
+  - name: v1
+    served: true
+    storage: true

--- a/charts/storageos-operator/v2.1.0/questions.yml
+++ b/charts/storageos-operator/v2.1.0/questions.yml
@@ -1,0 +1,165 @@
+categories:
+- storage
+labels:
+  io.rancher.certified: partner
+  io.cattle.role: cluster
+rancher_min_version: 2.4.0
+questions:
+- variable: k8sDistro
+  default: rancher
+  description: "Kubernetes Distribution is used to fine-tune configuration for
+  specific Kubernetes distributions. It is also included in anonymized
+  telemetry data so that we can focus development effort most effectively.
+  Example values: rancher, openshift"
+  type: string
+  label: Kubernetes Distribution
+
+# Operator image configuration.
+- variable: defaultImage
+  default: true
+  description: "Use default Docker images"
+  label: Use Default Images
+  type: boolean
+  show_subquestion_if: false
+  group: "Container Images"
+  subquestions:
+  - variable: operator.image.pullPolicy
+    default: IfNotPresent
+    description: "Operator Image pull policy"
+    type: enum
+    label: Operator Image pull policy
+    options:
+      - IfNotPresent
+      - Always
+      - Never
+  - variable: operator.image.repository
+    default: "storageos/cluster-operator"
+    description: "StorageOS operator image name"
+    type: string
+    label: StorageOS Operator Image Name
+  - variable: operator.image.tag
+    default: "v2.1.0"
+    description: "StorageOS Operator image tag"
+    type: string
+    label: StorageOS Operator Image Tag
+
+# Default minimal cluster configuration.
+- variable: cluster.create
+  default: true
+  type: boolean
+  description: "Install StorageOS cluster with minimal configurations"
+  label: "Install StorageOS cluster"
+  show_subquestion_if: true
+  group: "StorageOS Cluster"
+  subquestions:
+
+  # Cluster metadata.
+  - variable: cluster.name
+    default: "storageos"
+    description: "Name of the StorageOS cluster deployment"
+    type: string
+    label: Name
+  - variable: cluster.namespace
+    default: "kube-system"
+    description: "Namespace of the StorageOS cluster deployment. `kube-system` recommended to avoid pre-emption when node is under load."
+    type: string
+    label: Namespace
+
+  # Node container image.
+  - variable: cluster.images.node.repository
+    default: "storageos/node"
+    description: "StorageOS node container image name"
+    type: string
+    label: StorageOS Node Container Image Name
+  - variable: cluster.images.node.tag
+    default: "v2.1.0"
+    description: "StorageOS Node container image tag"
+    type: string
+    label: StorageOS Node Container Image Tag
+
+  # Telemetry.
+  - variable: cluster.disableTelemetry
+    default: false
+    type: boolean
+    description: "Disable telemetry data collection.  See https://docs.storageos.com/docs/reference/telemetry for more information."
+    label: Disable Telemetry
+
+  # Credentials.
+  - variable: cluster.admin.username
+    default: "admin"
+    description: "Username of the StorageOS administrator account"
+    type: string
+    label: Username
+  - variable: cluster.admin.password
+    default: ""
+    description: "Password of the StorageOS administrator account. Must be at
+    least 8 characters long"
+    type: password
+    label: Password
+
+  # KV store backend.
+  - variable: cluster.kvBackend.address
+    required: true
+    default: ""
+    description: "List of etcd targets, in the form ip[:port], separated by
+    commas. Prefer multiple direct endpoints over a single load-balanced
+    endpoint. See https://docs.storageos.com/docs/prerequisites/etcd/ for more
+    information."
+    type: string
+    label: External etcd address(es)
+  - variable: cluster.kvBackend.tls
+    default: false
+    type: boolean
+    description: "Enable etcd TLS"
+    label: "TLS should be configured for external etcd to protect configuration data (Optional)."
+    show_if: "cluster.kvBackend.embedded=false"
+  - variable: cluster.kvBackend.tlsSecretName
+    required: false
+    default: ""
+    description: "Name of the secret that contains the etcd TLS certs. This secret is typically shared with etcd."
+    type: string
+    label: External etcd TLS secret name
+    show_if: "cluster.kvBackend.tls=true"
+  - variable: cluster.kvBackend.tlsSecretNamespace
+    required: false
+    default: ""
+    description: "Namespace of the secret that contains the etcd TLS certs. This secret is typically shared with etcd."
+    type: string
+    label: External etcd TLS secret namespace
+    show_if: "cluster.kvBackend.tls=true"
+
+  # Node Selector Term.
+  - variable: cluster.nodeSelectorTerm.key
+    required: false
+    default: ""
+    description: "Key of the node selector term match expression used to select the nodes to install StorageOS on, e.g. `node-role.kubernetes.io/worker`"
+    type: string
+    label: Node selector term key
+  - variable: cluster.nodeSelectorTerm.value
+    required: false
+    default: ""
+    description: "Value of the node selector term match expression used to select the nodes to install StorageOS on."
+    type: string
+    label: Node selector term value
+
+  # Pod tolerations.
+  - variable: cluster.toleration.key
+    required: false
+    default: ""
+    description: "Key of pod toleration with operator 'Equal' and effect 'NoSchedule'"
+    type: string
+    label: Pod toleration key
+  - variable: cluster.toleration.value
+    required: false
+    default: ""
+    description: "Value of pod toleration with operator 'Equal' and effect 'NoSchedule'"
+    type: string
+    label: Pod toleration value
+
+  # Shared Directory
+  - variable: cluster.sharedDir
+    required: false
+    default: "/var/lib/kubelet/plugins/kubernetes.io~storageos"
+    description: "Shared Directory should be set if running kubelet in a container. This should be the path shared into to kubelet container, typically: '/var/lib/kubelet/plugins/kubernetes.io~storageos'.  If not set, defaults will be used."
+    type: string
+    label: Shared Directory

--- a/charts/storageos-operator/v2.1.0/templates/NOTES.txt
+++ b/charts/storageos-operator/v2.1.0/templates/NOTES.txt
@@ -1,0 +1,57 @@
+StorageOS Operator deployed.
+
+If you disabled automatic cluster creation, you can deploy a StorageOS cluster
+by creating a custom StorageOSCluster resource:
+
+1. Create a secret containing StorageOS cluster credentials. This secret
+contains the API username and password that will be used to authenticate to the
+StorageOS cluster. Base64 encode the username and password that you want to use
+for your StorageOS cluster.
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: storageos-api
+  namespace: storageos-operator
+  labels:
+    app: storageos
+type: kubernetes.io/storageos
+data:
+  # echo -n '<secret>' | base64
+  apiUsername: c3RvcmFnZW9z
+  apiPassword: c3RvcmFnZW9z
+  csiProvisionUsername: c3RvcmFnZW9z
+  csiProvisionPassword: c3RvcmFnZW9z
+  csiControllerPublishUsername: c3RvcmFnZW9z
+  csiControllerPublishPassword: c3RvcmFnZW9z
+  csiNodePublishUsername: c3RvcmFnZW9z
+  csiNodePublishPassword: c3RvcmFnZW9z
+  csiControllerExpandUsername: c3RvcmFnZW9z
+  csiControllerExpandPassword: c3RvcmFnZW9z
+
+2. Create a StorageOS custom resource that references the secret created
+above (storageos-api in the above example). When the resource is created, the
+cluster will be deployed.
+
+apiVersion: storageos.com/v1
+kind: StorageOSCluster
+metadata:
+  name: example-storageos
+  namespace: storageos-operator
+spec:
+  secretRefName: storageos-api
+  secretRefNamespace: storageos-operator
+  csi:
+    enable: true
+    deploymentStrategy: "deployment"
+    enableProvisionCreds: true
+    enableControllerPublishCreds: true
+    enableNodePublishCreds: true
+    enableControllerExpandCreds: true
+  kvBackend:
+    address: <etcd-endpoint>
+
+Newly installed StorageOS clusters require a license to function. For
+instructions on applying our free developer license, or obtaining a commercial
+license, please see our documentation at
+https://docs.storageos.com/docs/reference/licence/.

--- a/charts/storageos-operator/v2.1.0/templates/_helpers.tpl
+++ b/charts/storageos-operator/v2.1.0/templates/_helpers.tpl
@@ -1,0 +1,67 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "storageos.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "storageos.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "storageos.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "storageos.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "storageos.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate the admin username to be of minimum length
+*/}}
+{{- define "validate-username" -}}
+{{ $length := len .Values.cluster.admin.username }}
+{{- if ge $length 3 -}}
+{{ .Values.cluster.admin.username }}
+{{- else -}}
+{{- fail "Invalid username. Must be at least 3 characters." -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate the admin password to be of minimum length
+*/}}
+{{- define "validate-password" -}}
+{{ $length := len .Values.cluster.admin.password }}
+{{- if ge $length 8 -}}
+{{ .Values.cluster.admin.password }}
+{{- else -}}
+{{- fail "Invalid password. Must be at least 8 characters." -}}
+{{- end -}}
+{{- end -}}

--- a/charts/storageos-operator/v2.1.0/templates/cleanup.yaml
+++ b/charts/storageos-operator/v2.1.0/templates/cleanup.yaml
@@ -1,0 +1,180 @@
+{{- if .Values.cluster.create }}
+
+# ClusterRole, ClusterRoleBinding and ServiceAccounts have hook-failed in
+# hook-delete-policy to make it easy to rerun the whole setup even after a
+# failure, else the rerun fails with existing resource error.
+# Hook delete policy before-hook-creation ensures any other leftover resources
+# from previous run gets deleted when run again.
+# The Job resources will not be deleted to help investigage the failure.
+# Since the resources created by the operator are not managed by the chart, each
+# of them must be individually deleted in separate jobs.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: storageos-cleanup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": "hook-succeeded, hook-failed, before-hook-creation"
+    "helm.sh/hook-weight": "1"
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: storageos:cleanup
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": "hook-succeeded, hook-failed, before-hook-creation"
+    "helm.sh/hook-weight": "1"
+rules:
+# Using apiGroup "apps" for daemonsets fails and the permission error indicates
+# that it's in group "extensions". Not sure if it's a Job specific behavior,
+# because the daemonsets deployed by the operator use "apps" apiGroup.
+- apiGroups:
+  - extensions
+  resources:
+  - daemonsets
+  - deployments
+  verbs:
+  - delete
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - deployments
+  - daemonsets
+  verbs:
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - delete
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  verbs:
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  - secrets
+  - services
+  - configmaps
+  verbs:
+  - delete
+- apiGroups:
+  - storageos.com
+  resources:
+  - storageosclusters
+  verbs:
+  - get
+  - patch
+  - delete
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: storageos:cleanup
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": "hook-succeeded, hook-failed, before-hook-creation"
+    "helm.sh/hook-weight": "2"
+subjects:
+- name: storageos-cleanup
+  kind: ServiceAccount
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  name: storageos:cleanup
+  kind: ClusterRole
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+# Delete the StorageOSCluster object by removing the finalizer.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "storageos-storageoscluster-cleanup"
+  namespace: {{ .namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": "hook-succeeded, before-hook-creation"
+    "helm.sh/hook-weight": "3"
+spec:
+  template:
+    spec:
+      serviceAccountName: storageos-cleanup
+      containers:
+      - name: "storageos-storageoscluster-cleanup"
+        image: "{{ $.Values.cleanup.images.kubectl.repository }}:{{ $.Values.cleanup.images.kubectl.tag }}"
+        command:
+          - kubectl
+          - -n
+          - {{ $.Release.Namespace }}
+          - patch
+          - stos
+          - {{ $.Values.cluster.name }}
+          - --type=merge
+          - --patch={"metadata":{"finalizers":null}}
+      restartPolicy: Never
+  backoffLimit: 4
+
+---
+
+# Iterate through the Values.cleanup list and create jobs to delete all the
+# unmanaged resources of the cluster.
+
+{{- range .Values.cleanup.resources }}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "storageos-{{ .name }}-cleanup"
+  namespace: {{ .namespace }}
+  annotations:
+    "helm.sh/hook": post-delete
+    "helm.sh/hook-delete-policy": "hook-succeeded, before-hook-creation"
+    "helm.sh/hook-weight": "3"
+spec:
+  template:
+    spec:
+      serviceAccountName: storageos-cleanup
+      containers:
+      - name: "storageos-{{ .name }}-cleanup"
+        image: "{{ $.Values.cleanup.images.kubectl.repository }}:{{ $.Values.cleanup.images.kubectl.tag }}"
+        command:
+          - kubectl
+          - -n
+          - {{ $.Values.cluster.namespace }}
+          - delete
+          {{- range .command }}
+          - {{ . | quote }}
+          {{- end }}
+          - --ignore-not-found=true
+      restartPolicy: Never
+  backoffLimit: 4
+
+---
+
+{{- end }}
+
+
+{{- end }}

--- a/charts/storageos-operator/v2.1.0/templates/operator.yaml
+++ b/charts/storageos-operator/v2.1.0/templates/operator.yaml
@@ -1,0 +1,109 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "storageos.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "storageos.name" . }}
+    chart: {{ template "storageos.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ template "storageos.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "storageos.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ template "storageos.serviceAccountName" . }}
+      containers:
+        - name: storageos-operator
+          image: "{{ .Values.operator.image.repository }}:{{ .Values.operator.image.tag }}"
+          imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+          ports:
+          - containerPort: 8383
+            name: metrics
+          - containerPort: 8686
+            name: operatormetrics
+          - containerPort: 5720
+            name: podschedwebhook
+          command:
+          - cluster-operator
+          env:
+            {{- if and .Values.cluster.images.node.repository .Values.cluster.images.node.tag }}
+            - name: RELATED_IMAGE_STORAGEOS_NODE
+              value: "{{ .Values.cluster.images.node.repository }}:{{ .Values.cluster.images.node.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.init.repository .Values.cluster.images.init.tag }}
+            - name: RELATED_IMAGE_STORAGEOS_INIT
+              value: "{{ .Values.cluster.images.init.repository }}:{{ .Values.cluster.images.init.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV1ClusterDriverRegistrar.repository .Values.cluster.images.csiV1ClusterDriverRegistrar.tag }}
+            - name: RELATED_IMAGE_CSIV1_CLUSTER_DRIVER_REGISTRAR
+              value: "{{ .Values.cluster.images.csiV1ClusterDriverRegistrar.repository }}:{{ .Values.cluster.images.csiV1ClusterDriverRegistrar.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV1NodeDriverRegistrar.repository .Values.cluster.images.csiV1NodeDriverRegistrar.tag }}
+            - name: RELATED_IMAGE_CSIV1_NODE_DRIVER_REGISTRAR
+              value: "{{ .Values.cluster.images.csiV1NodeDriverRegistrar.repository }}:{{ .Values.cluster.images.csiV1NodeDriverRegistrar.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV1ExternalProvisioner.repository .Values.cluster.images.csiV1ExternalProvisioner.tag }}
+            - name: RELATED_IMAGE_CSIV1_EXTERNAL_PROVISIONER
+              value: "{{ .Values.cluster.images.csiV1ExternalProvisioner.repository }}:{{ .Values.cluster.images.csiV1ExternalProvisioner.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV1ExternalAttacher.repository .Values.cluster.images.csiV1ExternalAttacher.tag }}
+            - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER
+              value: "{{ .Values.cluster.images.csiV1ExternalAttacher.repository }}:{{ .Values.cluster.images.csiV1ExternalAttacher.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV1ExternalAttacherV2.repository .Values.cluster.images.csiV1ExternalAttacherV2.tag }}
+            - name: RELATED_IMAGE_CSIV1_EXTERNAL_ATTACHER_V2
+              value: "{{ .Values.cluster.images.csiV1ExternalAttacherV2.repository }}:{{ .Values.cluster.images.csiV1ExternalAttacherV2.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV1LivenessProbe.repository .Values.cluster.images.csiV1LivenessProbe.tag }}
+            - name: RELATED_IMAGE_CSIV1_LIVENESS_PROBE
+              value: "{{ .Values.cluster.images.csiV1LivenessProbe.repository }}:{{ .Values.cluster.images.csiV1LivenessProbe.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV1ExternalResizer.repository .Values.cluster.images.csiV1ExternalResizer.tag }}
+            - name: RELATED_IMAGE_CSIV1_EXTERNAL_RESIZER
+              value: "{{ .Values.cluster.images.csiV1ExternalResizer.repository }}:{{ .Values.cluster.images.csiV1ExternalResizer.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV0DriverRegistrar.repository .Values.cluster.images.csiV0DriverRegistrar.tag }}
+            - name: RELATED_IMAGE_CSIV0_DRIVER_REGISTRAR
+              value: "{{ .Values.cluster.images.csiV0DriverRegistrar.repository }}:{{ .Values.cluster.images.csiV0DriverRegistrar.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV0ExternalProvisioner.repository .Values.cluster.images.csiV0ExternalProvisioner.tag }}
+            - name: RELATED_IMAGE_CSIV0_EXTERNAL_PROVISIONER
+              value: "{{ .Values.cluster.images.csiV0ExternalProvisioner.repository }}:{{ .Values.cluster.images.csiV0ExternalProvisioner.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.csiV0ExternalAttacher.repository .Values.cluster.images.csiV0ExternalAttacher.tag }}
+            - name: RELATED_IMAGE_CSIV0_EXTERNAL_ATTACHER
+              value: "{{ .Values.cluster.images.csiV0ExternalAttacher.repository }}:{{ .Values.cluster.images.csiV0ExternalAttacher.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.nfs.repository .Values.cluster.images.nfs.tag }}
+            - name: RELATED_IMAGE_NFS
+              value: "{{ .Values.cluster.images.nfs.repository }}:{{ .Values.cluster.images.nfs.tag }}"
+            {{- end }}
+            {{- if and .Values.cluster.images.kubeScheduler.repository .Values.cluster.images.kubeScheduler.tag }}
+            - name: RELATED_IMAGE_KUBE_SCHEDULER
+              value: "{{ .Values.cluster.images.kubeScheduler.repository }}:{{ .Values.cluster.images.kubeScheduler.tag }}"
+            {{- end }}
+            - name: WATCH_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: OPERATOR_NAME
+              value: "storageos-cluster-operator"
+            - name: DISABLE_SCHEDULER_WEBHOOK
+              value: "false"

--- a/charts/storageos-operator/v2.1.0/templates/psp.yaml
+++ b/charts/storageos-operator/v2.1.0/templates/psp.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.podSecurityPolicy.enabled }}
+
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "storageos.fullname" . }}-psp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "storageos.name" . }}
+    chart: {{ template "storageos.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  annotations:
+{{- if .Values.podSecurityPolicy.annotations }}
+{{ toYaml .Values.podSecurityPolicy.annotations | indent 4 }}
+{{- end }}
+spec:
+  volumes:
+  - '*'
+  runAsUser:
+    rule: 'RunAsAny'
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'RunAsAny'
+  fsGroup:
+    rule: 'RunAsAny'
+
+{{- end }}

--- a/charts/storageos-operator/v2.1.0/templates/rbac.yaml
+++ b/charts/storageos-operator/v2.1.0/templates/rbac.yaml
@@ -1,0 +1,239 @@
+# Role for storageos operator
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: storageos:operator
+  labels:
+    app: {{ template "storageos.name" . }}
+    chart: {{ template "storageos.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+- apiGroups:
+  - storageos.com
+  resources:
+  - storageosclusters
+  - storageosclusters/status
+  - storageosupgrades
+  - storageosupgrades/status
+  - jobs
+  - jobs/status
+  - nfsservers
+  - nfsservers/status
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  - daemonsets
+  - deployments
+  - replicasets
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+  - create
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - list
+  - watch
+  - get
+  - update
+  - patch
+  - delete
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - serviceaccounts
+  - secrets
+  - services
+  - services/finalizers
+  - persistentvolumeclaims
+  - persistentvolumeclaims/status
+  - persistentvolumes
+  - configmaps
+  - replicationcontrollers
+  - pods/binding
+  - pods/status
+  - endpoints
+  verbs:
+  - create
+  - patch
+  - get
+  - list
+  - delete
+  - watch
+  - update
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - volumeattachments
+  - csinodeinfos
+  - csinodes
+  - csidrivers
+  verbs:
+  - create
+  - delete
+  - watch
+  - list
+  - get
+  - update
+  - patch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - csi.storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
+  - delete
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - create
+  - delete
+  - update
+  - get
+  - use
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  verbs:
+  - "*"
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - deployments/finalizers
+  resourceNames:
+  - storageos-cluster-operator
+  verbs:
+  - update
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+
+---
+
+# Bind operator service account to storageos-operator role
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: storageos:operator
+  labels:
+    app: {{ template "storageos.name" . }}
+    chart: {{ template "storageos.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "storageos.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: storageos:operator
+  apiGroup: rbac.authorization.k8s.io
+
+{{- if .Values.podSecurityPolicy.enabled }}
+---
+
+# ClusterRole for using pod security policy.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: storageos:psp-user
+  labels:
+    app: {{ template "storageos.name" . }}
+    chart: {{ template "storageos.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: ["extensions"]
+  resources: ["podsecuritypolicies"]
+  verbs: ["use"]
+  resourceNames:
+  - {{ template "storageos.fullname" . }}-psp
+
+---
+
+# Bind pod security policy cluster role to the operator service account.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: storageos:psp-user
+  labels:
+    app: {{ template "storageos.name" . }}
+    chart: {{ template "storageos.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+   apiGroup: rbac.authorization.k8s.io
+   kind: ClusterRole
+   name: storageos:psp-user
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "storageos.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+
+{{- end }}

--- a/charts/storageos-operator/v2.1.0/templates/secrets.yaml
+++ b/charts/storageos-operator/v2.1.0/templates/secrets.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.cluster.create }}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.cluster.secretRefName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "storageos.name" . }}
+    chart: {{ template "storageos.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+type: "kubernetes.io/storageos"
+data:
+  apiUsername: {{ include "validate-username" . | b64enc | quote }}
+  apiPassword: {{ include "validate-password" . | b64enc | quote }}
+  # Add base64 encoded TLS cert and key below if ingress.tls is set to true.
+  # tls.crt:
+  # tls.key:
+  # Add base64 encoded creds below for CSI credentials. The credentials are
+  # validated above. Use them here directly.
+  csiProvisionUsername: {{ .Values.cluster.admin.username | b64enc | quote }}
+  csiProvisionPassword: {{ .Values.cluster.admin.password | b64enc | quote }}
+  csiControllerPublishUsername: {{ .Values.cluster.admin.username | b64enc | quote }}
+  csiControllerPublishPassword: {{ .Values.cluster.admin.password | b64enc | quote }}
+  csiNodePublishUsername: {{ .Values.cluster.admin.username | b64enc | quote }}
+  csiNodePublishPassword: {{ .Values.cluster.admin.password | b64enc | quote }}
+  csiControllerExpandUsername: {{ .Values.cluster.admin.username | b64enc | quote }}
+  csiControllerExpandPassword: {{ .Values.cluster.admin.password | b64enc | quote }}
+
+{{- end }}

--- a/charts/storageos-operator/v2.1.0/templates/service-account.yaml
+++ b/charts/storageos-operator/v2.1.0/templates/service-account.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "storageos.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "storageos.name" . }}
+    chart: {{ template "storageos.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}

--- a/charts/storageos-operator/v2.1.0/templates/storageoscluster_cr.yaml
+++ b/charts/storageos-operator/v2.1.0/templates/storageoscluster_cr.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.cluster.create }}
+
+apiVersion: storageos.com/v1
+kind: StorageOSCluster
+metadata:
+  name: {{ .Values.cluster.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  namespace: {{ .Values.cluster.namespace }}
+  secretRefName: {{ .Values.cluster.secretRefName }}
+  secretRefNamespace: {{ .Release.Namespace }}
+  disableTelemetry: {{ .Values.cluster.disableTelemetry }}
+
+  {{- if .Values.k8sDistro }}
+  k8sDistro: {{ .Values.k8sDistro }}
+  {{- end }}
+
+  csi:
+    enable: true
+    deploymentStrategy: {{ .Values.cluster.csi.deploymentStrategy }}
+    enableProvisionCreds: true
+    enableControllerPublishCreds: true
+    enableNodePublishCreds: true
+    enableControllerExpandCreds: true
+
+  {{- if .Values.cluster.sharedDir }}
+  sharedDir: {{ .Values.cluster.sharedDir }}
+  {{- end }}
+
+  kvBackend:
+    address: {{ required "kv backend address must be set" .Values.cluster.kvBackend.address }}
+    backend: {{ .Values.cluster.kvBackend.backend }}
+  {{- if .Values.cluster.kvBackend.tlsSecretName }}
+  tlsEtcdSecretRefName: {{ .Values.cluster.kvBackend.tlsSecretName }}
+  {{- end }}
+  {{- if .Values.cluster.kvBackend.tlsSecretNamespace }}
+  tlsEtcdSecretRefNamespace: {{ .Values.cluster.kvBackend.tlsSecretNamespace }}
+  {{- end }}
+
+  {{- if .Values.cluster.nodeSelectorTerm.key }}
+  nodeSelectorTerms:
+    - matchExpressions:
+        - key: {{ .Values.cluster.nodeSelectorTerm.key }}
+          operator: In
+          values:
+          - "{{ .Values.cluster.nodeSelectorTerm.value }}"
+  {{- end }}
+
+  {{- if .Values.cluster.toleration.key }}
+  tolerations:
+    - key: {{ .Values.cluster.toleration.key }}
+      operator: "Equal"
+      value: {{ .Values.cluster.toleration.value }}
+      effect: "NoSchedule"
+  {{- end }}
+
+{{- end }}

--- a/charts/storageos-operator/v2.1.0/values.yaml
+++ b/charts/storageos-operator/v2.1.0/values.yaml
@@ -1,0 +1,212 @@
+# Default values for storageos.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+name: storageos-operator
+
+k8sDistro: default
+
+serviceAccount:
+  create: true
+  name: storageos-operator-sa
+
+podSecurityPolicy:
+  enabled: false
+  annotations:
+    {}
+    ## Specify pod annotations
+    ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#apparmor
+    ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#seccomp
+    ## Ref: https://kubernetes.io/docs/concepts/policy/pod-security-policy/#sysctl
+    ##
+    # seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+    # seccomp.security.alpha.kubernetes.io/defaultProfileName: 'docker/default'
+    # apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
+
+# operator-specific configuation parameters.
+operator:
+  image:
+    repository: storageos/cluster-operator
+    tag: v2.1.0
+    pullPolicy: IfNotPresent
+
+# cluster-specific configuation parameters.
+cluster:
+  # set create to true if the operator should auto-create the StorageOS cluster.
+  create: true
+
+  # Name of the deployment.
+  name: storageos
+
+  # Namespace to install the StorageOS cluster into.
+  namespace: kube-system
+
+  # Name of the secret containing StorageOS API credentials.
+  secretRefName: storageos-api
+
+  # Default admin account.
+  admin:
+    # Username to authenticate to the StorageOS API with.
+    username: storageos
+
+    # Password to authenticate to the StorageOS API with. This must be at least
+    # 8 characters long.
+    password:
+
+  # sharedDir should be set if running kubelet in a container.  This should
+  # be the path shared into to kubelet container, typically:
+  # "/var/lib/kubelet/plugins/kubernetes.io~storageos".  If not set, defaults
+  # will be used.
+  sharedDir:
+
+  # Key-Value store backend.
+  kvBackend:
+    embedded: false
+    address:
+    backend: etcd
+    tlsSecretName:
+    tlsSecretNamespace:
+
+  # Node selector terms to install StorageOS on.
+  nodeSelectorTerm:
+    key:
+    value:
+
+  # Pod toleration for the StorageOS pods.
+  toleration:
+    key:
+    value:
+
+  # To disable anonymous usage reporting across the cluster, set to true.
+  # Defaults to false. To help improve the product, data such as API usage and
+  # StorageOS configuration information is collected.
+  disableTelemetry: false
+
+  images:
+    # nodeContainer is the StorageOS node image to use, available from the
+    # [Docker Hub](https://hub.docker.com/r/storageos/node/).
+    node:
+      repository:
+      tag:
+    init:
+      repository:
+      tag:
+    csiV1ClusterDriverRegistrar:
+      repository:
+      tag:
+    csiV1NodeDriverRegistrar:
+      repository:
+      tag:
+    csiV1ExternalProvisioner:
+      repository:
+      tag:
+    csiV1ExternalAttacher:
+      repository:
+      tag:
+    csiV1ExternalAttacherV2:
+      repository:
+      tag:
+    csiV1LivenessProbe:
+      repository:
+      tag:
+    csiV1ExternalResizer:
+      repository:
+      tag:
+    csiV0DriverRegistrar:
+      repository:
+      tag:
+    csiV0ExternalProvisioner:
+      repository:
+      tag:
+    csiV0ExternalAttacher:
+      repository:
+      tag:
+    nfs:
+      repository:
+      tag:
+    kubeScheduler:
+      repository:
+      tag:
+
+  csi:
+    deploymentStrategy: deployment
+
+# The following is used for cleaning up unmanaged cluster resources when
+# auto-install is enabled.
+cleanup:
+  images:
+    kubectl:
+      repository: bitnami/kubectl
+      tag: 1.18.2
+  resources:
+    - name: daemonset
+      command:
+        - "daemonset"
+        - "storageos-daemonset"
+    - name: statefulset
+      command:
+        - "statefulset"
+        - "storageos-statefulset"
+    - name: csi-helper
+      command:
+        - "deployment"
+        - "storageos-csi-helper"
+    - name: scheduler
+      command:
+        - "deployment"
+        - "storageos-scheduler"
+    - name: configmap
+      command:
+        - "configmap"
+        - "storageos-scheduler-config"
+        - "storageos-scheduler-policy"
+    - name: serviceaccount
+      command:
+        - "serviceaccount"
+        - "storageos-daemonset-sa"
+        - "storageos-statefulset-sa"
+        - "storageos-csi-helper-sa"
+        - "storageos-scheduler-sa"
+    - name: role
+      command:
+        - "role"
+        - "storageos:key-management"
+    - name: rolebinding
+      command:
+        - "rolebinding"
+        - "storageos:key-management"
+    - name: secret
+      command:
+        - "secret"
+        - "init-secret"
+    - name: service
+      command:
+        - "service"
+        - "storageos"
+    - name: clusterrole
+      command:
+        - "clusterrole"
+        - "storageos:driver-registrar"
+        - "storageos:csi-attacher"
+        - "storageos:csi-provisioner"
+        - "storageos:pod-fencer"
+        - "storageos:scheduler-extender"
+        - "storageos:init"
+        - "storageos:nfs-provisioner"
+        - "storageos:csi-resizer"
+    - name: clusterrolebinding
+      command:
+        - "clusterrolebinding"
+        - "storageos:csi-provisioner"
+        - "storageos:csi-attacher"
+        - "storageos:driver-registrar"
+        - "storageos:k8s-driver-registrar"
+        - "storageos:pod-fencer"
+        - "storageos:scheduler-extender"
+        - "storageos:init"
+        - "storageos:nfs-provisioner"
+        - "storageos:csi-resizer"
+    - name: storageclass
+      command:
+        - "storageclass"
+        - "fast"


### PR DESCRIPTION
This adds StorageOS chart in rancher helm3 chart catalog. This is based on the previous chart in https://github.com/rancher/charts/tree/master/proposed/storageos-operator, updated to support helm3.