### PR TITLE
Make iSCSI CHAP non-mandatory

### DIFF
--- a/charts/hpe-csi-driver/v1.3.1/Chart.yaml
+++ b/charts/hpe-csi-driver/v1.3.1/Chart.yaml
@@ -9,7 +9,7 @@ sources:
 - https://scod.hpedev.io/csi_driver
 name: hpe-csi-driver
 home: https://hpe.com/storage/containers
-version: 1.3.0
+version: 1.3.1
 keywords:
   - HPE
   - Storage

--- a/charts/hpe-csi-driver/v1.3.1/Chart.yaml
+++ b/charts/hpe-csi-driver/v1.3.1/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+appVersion: 1.3.0
+description: A Helm chart for installing the HPE CSI Driver for Kubernetes
+icon: file://../hpedev.png
+maintainers:
+- name: datamattsson
+  email: hpe-containers-dev@hpe.com
+sources:
+- https://scod.hpedev.io/csi_driver
+name: hpe-csi-driver
+home: https://hpe.com/storage/containers
+version: 1.3.0
+keywords:
+  - HPE
+  - Storage
+  - StorageClass
+  - CentOS
+  - Ubuntu
+  - RHEL

--- a/charts/hpe-csi-driver/v1.3.1/README.md
+++ b/charts/hpe-csi-driver/v1.3.1/README.md
@@ -1,0 +1,110 @@
+# HPE CSI Driver for Kubernetes Helm chart
+
+The [HPE CSI Driver for Kubernetes](https://scod.hpedev.io/csi_driver/index.html) leverages HPE storage platforms to provide scalable and persistent storage for stateful applications.
+
+## Prerequisites
+
+- Upstream Kubernetes version >= 1.15
+- Most Kubernetes distributions are supported
+- Recent Ubuntu, SLES, CentOS or RHEL compute nodes connected to their respective official package repositories
+- Helm 3 (Version >= 3.2.0 required)
+
+Depending on which [Container Storage Provider](https://scod.hpedev.io/container_storage_provider/index.html) (CSP) is being used, other prerequisites and requirements may apply, such as storage platform OS and features.
+
+- [HPE Nimble Storage](https://scod.hpedev.io/container_storage_provider/hpe_nimble_storage/index.html)
+- [HPE 3PAR and Primera](https://scod.hpedev.io/container_storage_provider/hpe_3par_primera/index.html)
+
+## Configuration and installation
+
+The following table lists the configurable parameters of the HPE-CSI chart and their default values.
+
+|  Parameter                |  Description                                                           |  Default     |
+|---------------------------|------------------------------------------------------------------------|--------------|
+| logLevel                  | Log level. Can be one of `info`, `debug`, `trace`, `warn` and `error`. | info         |
+| imagePullPolicy           | Image pull policy (`Always`, `IfNotPresent`, `Never`).                 | IfNotPresent |
+| disableNodeConformance    | Disable automatic installation of iSCSI/Multipath Packages.            | false        |
+| iscsi.chapUser            | Username for iSCSI CHAP authentication.                                | ""           |
+| iscsi.chapPassword        | Password for iSCSI CHAP authentication.                                | ""           |
+
+It's recommended to create a [values.yaml](https://github.com/hpe-storage/co-deployments/blob/master/helm/values/csi-driver) file from the corresponding release of the chart and edit it to fit the environment the chart is being deployed to. Download and edit [a sample file](https://github.com/hpe-storage/co-deployments/blob/master/helm/values/csi-driver).
+
+These are the bare minimum required parameters for a successful deployment to an iSCSI environment if CHAP authentication is required.
+
+```
+iscsi:
+  chapUser: <username>
+  chapPassword: <password>
+```
+
+Tweak any additional parameters to suit the environment or as prescribed by HPE.
+
+### Installing the chart
+
+To install the chart with the name `hpe-csi`:
+
+Add HPE helm repo:
+
+```
+helm repo add hpe https://hpe-storage.github.io/co-deployments
+helm repo update
+```
+
+Install the latest chart:
+
+```
+helm install hpe-csi hpe/hpe-csi-driver --namespace kube-system -f myvalues.yaml
+```
+
+**Note**: values.yaml is optional if no parameters are overridden from defaults.
+
+### Upgrading the Chart
+
+To upgrade the chart, specify the version you want to upgrade to as below. Please do NOT re-use a full blown `values.yaml` from prior versions to upgrade to later versions. Always use `values.yaml` from corresponding release from [values.yaml](https://github.com/hpe-storage/co-deployments/blob/master/helm/values/csi-driver)
+
+List the avaiable version of the plugin:
+
+```
+helm repo update
+helm search repo hpe-csi-driver -l
+```
+
+Select the target version to upgrade as below:
+
+```
+helm upgrade hpe-csi hpe/hpe-csi-driver --namespace kube-system --version=x.x.x.x -f myvalues.yaml
+```
+
+### Uninstalling the Chart
+
+To uninstall the `hpe-csi` chart:
+
+```
+helm uninstall hpe-csi --namespace kube-system
+```
+
+**Note**: Due to a limitation in Helm, CRDs are not deleted as part of the chart uninstall.
+
+### Alternative install method
+
+In some cases it's more practical to provide the local configuration via the `helm` CLI directly. Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. These will take precedence over entries in [values.yaml](https://github.com/hpe-storage/co-deployments/blob/master/helm/values/csi-driver). For example:
+
+```
+helm install hpe-csi hpe/hpe-csi-driver --namespace kube-system --set iscsi.chapUsername=admin \
+--set iscsi.chapPassword=xxxxxxxx
+```
+
+## Using persistent storage with Kubernetes
+
+Enable dynamic provisioning of persistent storage by creating a `StorageClass` API object that references a `Secret` which maps to a supported HPE primary storage backend. Refer to the [HPE CSI Driver for Kubernetes](https://scod.hpedev.io/csi_driver/using.html) documentation on [HPE Storage Container Orchestration Documentation](https://scod.hpedev.io/). Also, it's helpful to be familiar with [persistent storage concepts](https://kubernetes.io/docs/concepts/storage/volumes/) in Kubernetes prior to deploying stateful workloads.
+
+## Support
+
+The HPE CSI Driver for Kubernetes Helm chart is covered by your HPE support contract. Please file any issues, questions or feature requests [here](https://github.com/hpe-storage/co-deployments/issues) or contact HPE through the regular support channels. You may also join our Slack community to chat with HPE folks close to this project. We hang out in `#NimbleStorage`, `#3par-primera` and `#Kubernetes` at [hpedev.slack.com](https://hpedev.slack.com), sign up here: [slack.hpedev.io](https://slack.hpedev.io/).
+
+## Contributing
+
+We value all feedback and contributions. If you find any issues or want to contribute, please feel free to open an issue or file a PR. More details in [CONTRIBUTING.md](https://github.com/hpe-storage/co-deployments/blob/master/CONTRIBUTING.md)
+
+## License
+
+This is open source software licensed using the Apache License 2.0. Please see [LICENSE](https://github.com/hpe-storage/co-deployments/blob/master/LICENSE) for details.

--- a/charts/hpe-csi-driver/v1.3.1/app-readme.md
+++ b/charts/hpe-csi-driver/v1.3.1/app-readme.md
@@ -1,0 +1,3 @@
+# HPE CSI Driver for Kubernetes
+
+The [HPE CSI Driver for Kubernetes](https://github.com/hpe-storage/csi-driver) leverages HPE storage platforms to provide scalable and persistent storage for stateful applications.

--- a/charts/hpe-csi-driver/v1.3.1/crds/hpe-nodeinfo-crd.yaml
+++ b/charts/hpe-csi-driver/v1.3.1/crds/hpe-nodeinfo-crd.yaml
@@ -1,0 +1,54 @@
+---
+#############################################
+############  HPE Node Info CRD  ############
+#############################################
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: hpenodeinfos.storage.hpe.com
+spec:
+  group: storage.hpe.com
+  names:
+    kind: HPENodeInfo
+    plural: hpenodeinfos
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        hpeNodes:
+          description: List of HPE nodes configured for storage access.
+          items:
+            properties:
+              uuid:
+                description: The UUID of the node.
+                type: string
+              iqns:
+                description: List of IQNs configured on the node.
+                items:
+                  type: string
+                type: array
+              chapUser:
+                  description: The CHAP User Name
+                  type: string
+              chapPassword:
+                 description: The CHAP Password
+                 type: string
+              networks:
+                description: List of networks configured on the node.
+                items:
+                  type: string
+                type: array
+              wwpns:
+                description: List of WWPNs configured on the node.
+                items:
+                  type: string
+                type: array
+          type: array
+  version: v1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/hpe-csi-driver/v1.3.1/crds/hpe-replicated-device-info-crd.yaml
+++ b/charts/hpe-csi-driver/v1.3.1/crds/hpe-replicated-device-info-crd.yaml
@@ -1,0 +1,57 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: hpereplicationdeviceinfos.storage.hpe.com
+spec:
+  group: storage.hpe.com
+  names:
+    kind: HPEReplicationDeviceInfo
+    plural: hpereplicationdeviceinfos
+    shortNames:
+      - hperdi
+
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        hpeReplicationDeviceInfos:
+          description: List of HPE Replicated Arrays configured for 3PAR/Primera arrays.
+          items:
+            properties:
+              targets:
+                description: Target Array Details
+                type: array
+                items:
+                  properties:
+                    targetName:
+                      description: Target Name of the array
+                      type: string
+                    targetCpg:
+                      description: Target CPG of the array
+                      type: string
+                    targetSnapCpg:
+                      description: Target Snap CPG of the array
+                      type: string
+                    targetSecret:
+                      description: Secret of the replicated array
+                      type: string
+                    targetMode:
+                      description: Replication Mode
+                      type: string
+                    targetSecretNamespace:
+                      description: Namespace of secret
+                      type: string
+                  required:
+                    - targetName
+                    - targetCpg
+                    - targetSecret
+                    - targetSecretNamespace
+          type: array
+  version: v1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/hpe-csi-driver/v1.3.1/crds/hpe-volumeinfo-crd.yaml
+++ b/charts/hpe-csi-driver/v1.3.1/crds/hpe-volumeinfo-crd.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: hpevolumeinfos.storage.hpe.com
+spec:
+  group: storage.hpe.com
+  names:
+    kind: HPEVolumeInfo
+    plural: hpevolumeinfos
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        hpeVolumes:
+          description: List of HPE volumes configured for 3PAR/Primera arrays.
+          items:
+            properties:
+              uuid:
+                description: The UUID of the volume.
+                type: string
+              record:
+                description: Metadata for the volume.
+                type: map[string]string
+          type: array
+  version: v1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []

--- a/charts/hpe-csi-driver/v1.3.1/files/config.json
+++ b/charts/hpe-csi-driver/v1.3.1/files/config.json
@@ -1,0 +1,128 @@
+[
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Manual startup of iSCSI nodes on boot. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "startup",
+        "recommendation": "manual"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Replacement_timeout of 10 seconds is recommended for faster failover of I/O by multipath on path failures. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "replacement_timeout",
+        "recommendation": "10"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Minimum login timeout of 15 seconds is recommended with iSCSI. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "login_timeout",
+        "recommendation": "15"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Minimum timeout of 10 seconds is recommended with noop requests. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "noop_out_timeout",
+        "recommendation": "10"
+    },
+    {
+        "category": "iscsi",
+        "severity": "info",
+        "description": "Minimum cmds_max of 512 is recommended for each session if handling multiple LUN's. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "cmds_max",
+        "recommendation": "512"
+    },
+    {
+        "category": "iscsi",
+        "severity": "warning",
+        "description": "Minimum queue_depth of 256 is recommended for each iSCSI session/path. Can be set in /etc/iscsi/iscsid.conf",
+        "parameter": "queue_depth",
+        "recommendation": "256"
+    },
+    {
+        "category": "iscsi",
+        "severity": "info",
+        "description": "Minimum number of sessions per iSCSI login is recommended to be 1 by default. If additional sessions are needed this can be set in /etc/iscsi/iscsid.conf. If NCM is running, please change min_session_per_array in /etc/ncm.conf and restart nlt service instead",
+        "parameter": "nr_sessions",
+        "recommendation": "1"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "product attribute recommended to be set to Server in /etc/multipath.conf",
+        "parameter": "product",
+        "recommendation": "\"Server\""
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "alua prioritizer is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "prio",
+        "recommendation": "alua"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "scsi_dh_alua device handler is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "hardware_handler",
+        "recommendation": "\"1 alua\""
+    },
+    {
+        "category": "multipath",
+        "severity": "warning",
+        "description": "immediate failback setting is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "failback",
+        "recommendation": "immediate"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "immediately fail i/o on transient path failures to retry on other paths, value=1. Can be set in /etc/multipath.conf",
+        "parameter": "fast_io_fail_tmo",
+        "recommendation": "5"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "queueing is recommended for 150 seconds, with no_path_retry value of 30. Can be set in /etc/multipath.conf",
+        "parameter": "no_path_retry",
+        "recommendation": "30"
+    },
+    {
+        "category": "multipath",
+        "severity": "warning",
+        "description": "service-time path selector is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "path_selector",
+        "recommendation": "\"service-time 0\""
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "vendor attribute recommended to be set to Nimble in /etc/multipath.conf",
+        "parameter": "vendor",
+        "recommendation": "\"Nimble\""
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "group paths according to ALUA path priority of active/standby. Recommended to be set to group_by_prio in /etc/multipath.conf",
+        "parameter": "path_grouping_policy",
+        "recommendation": "group_by_prio"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "tur path checker is recommended. Can be set in /etc/multipath.conf",
+        "parameter": "path_checker",
+        "recommendation": "tur"
+    },
+    {
+        "category": "multipath",
+        "severity": "critical",
+        "description": "infinite value is recommended for timeout in cases of device loss for FC. Can be set in /etc/multipath.conf",
+        "parameter": "dev_loss_tmo",
+        "recommendation": "infinity"
+    }
+]

--- a/charts/hpe-csi-driver/v1.3.1/questions.yml
+++ b/charts/hpe-csi-driver/v1.3.1/questions.yml
@@ -22,12 +22,12 @@ questions:
 - variable: iscsi.chapUser
   label: "iSCSI CHAP Username"
   type: string
-  required: true
+  required: false
   description: "Specify username for iSCSI CHAP authentication"
   group: "HPE iSCSI settings"
 - variable: iscsi.chapPassword
   label: "iSCSI CHAP Password"
   type: password
-  required: true
+  required: false
   description: "Specify password for iSCSI CHAP authentication"
   group: "HPE iSCSI settings"

--- a/charts/hpe-csi-driver/v1.3.1/questions.yml
+++ b/charts/hpe-csi-driver/v1.3.1/questions.yml
@@ -1,0 +1,33 @@
+labels:
+  io.rancher.certified: partner
+categories:
+- storage
+questions:
+- variable: imagePullPolicy
+  label: "ImagePullPolicy"
+  default: "IfNotPresent"
+  type: enum
+  options:
+    - "IfNotPresent"
+    - "Always"
+    - "Never"
+  description: "ImagePullPolicy for all CSI driver images"
+  group: "HPE CSI Driver settings"
+- variable: disableNodeConformance
+  label: "Disable automatic installation of iSCSI/Multipath Packages"
+  type: boolean
+  default: false
+  description: "Disable automatic installation of iSCSI/Multipath Packages"
+  group: "HPE CSI Driver settings"
+- variable: iscsi.chapUser
+  label: "iSCSI CHAP Username"
+  type: string
+  required: true
+  description: "Specify username for iSCSI CHAP authentication"
+  group: "HPE iSCSI settings"
+- variable: iscsi.chapPassword
+  label: "iSCSI CHAP Password"
+  type: password
+  required: true
+  description: "Specify password for iSCSI CHAP authentication"
+  group: "HPE iSCSI settings"

--- a/charts/hpe-csi-driver/v1.3.1/templates/_helpers.tpl
+++ b/charts/hpe-csi-driver/v1.3.1/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hpe-csi-storage.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "hpe-csi-storage.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hpe-csi-storage.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/hpe-csi-driver/v1.3.1/templates/csi-driver-crd.yaml
+++ b/charts/hpe-csi-driver/v1.3.1/templates/csi-driver-crd.yaml
@@ -1,0 +1,16 @@
+{{- if semverCompare ">=1.14.0" .Capabilities.KubeVersion.GitVersion }}
+---
+
+################# CSI Driver ###########
+apiVersion: storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: csi.hpe.com
+spec:
+  podInfoOnMount: true
+  {{- if semverCompare ">=1.16.0" .Capabilities.KubeVersion.GitVersion }}
+  volumeLifecycleModes:
+  - Persistent
+  - Ephemeral
+  {{- end }}
+{{- end }}

--- a/charts/hpe-csi-driver/v1.3.1/templates/hpe-csi-controller.yaml
+++ b/charts/hpe-csi-driver/v1.3.1/templates/hpe-csi-controller.yaml
@@ -1,0 +1,171 @@
+---
+
+#############################################
+############  Controller driver  ############
+#############################################
+
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: hpe-csi-controller
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hpe-csi-controller
+  template:
+    metadata:
+      labels:
+        app: hpe-csi-controller
+        role: hpe-csi
+    spec:
+      serviceAccount: hpe-csi-controller-sa
+      {{- if semverCompare ">=1.17.0" .Capabilities.KubeVersion.GitVersion }}
+      priorityClassName: system-cluster-critical
+      {{- end }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      containers:
+        - name: csi-provisioner
+          {{- if semverCompare "<=1.16.0" .Capabilities.KubeVersion.GitVersion }}
+          image: quay.io/k8scsi/csi-provisioner:v1.4.0
+          {{- else }}
+          image: quay.io/k8scsi/csi-provisioner:v1.5.0
+          {{- end }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+            {{- if semverCompare ">= 1.13.0" .Capabilities.KubeVersion.GitVersion }}
+            - "--timeout=30s"
+            - "--worker-threads=16"
+            {{- end }}
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy
+        - name: csi-attacher
+          {{- if semverCompare "~1.13.0" .Capabilities.KubeVersion.GitVersion }}
+          image: quay.io/k8scsi/csi-attacher:v1.1.0
+          {{- else }}
+          image: quay.io/k8scsi/csi-attacher:v2.1.1
+          {{- end }}
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy
+        {{- if semverCompare ">=1.17.0" .Capabilities.KubeVersion.GitVersion }}
+        - name: csi-snapshotter
+          image: quay.io/k8scsi/csi-snapshotter:v2.0.1
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: "Always"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        {{- end }}
+        {{- if semverCompare ">=1.15.0" .Capabilities.KubeVersion.GitVersion }}
+        - name: csi-resizer
+          image: quay.io/k8scsi/csi-resizer:v0.4.0
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--v=5"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi.sock
+          imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy
+        {{- end }}
+        - name: hpe-csi-driver
+          image: hpestorage/csi-driver:v1.3.0
+          args :
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--flavor=kubernetes"
+            - "--pod-monitor"
+            - "--pod-monitor-interval=30"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi.sock
+            - name: LOG_LEVEL
+              value: {{ .Values.logLevel }}
+          imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy
+            - name: log-dir
+              mountPath: /var/log
+            - name: k8s
+              mountPath: /etc/kubernetes
+            - name: hpeconfig
+              mountPath: /etc/hpe-storage
+            - name: root-dir
+              mountPath: /host
+        - name: csi-volume-mutator
+          image: quay.io/hpestorage/volume-mutator:v1.0.0
+          args:
+            - "--v=5"
+            - "--csi-address=$(ADDRESS)"
+          env:
+            - name: ADDRESS
+              value: /var/lib/csi/sockets/pluginproxy/csi-extensions.sock
+          imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+        - name: csi-extensions
+          image: quay.io/hpestorage/csi-extensions:v1.0.0
+          args:
+            - "--v=5"
+            - "--endpoint=$(CSI_ENDPOINT)"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///var/lib/csi/sockets/pluginproxy/csi-extensions.sock
+            - name: LOG_LEVEL
+              value: {{ .Values.logLevel }}
+          imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/lib/csi/sockets/pluginproxy/
+      volumes:
+        - name: socket-dir
+          emptyDir: {}
+        - name: log-dir
+          hostPath:
+            path: /var/log
+        - name: k8s
+          hostPath:
+            path: /etc/kubernetes
+        - name: hpeconfig
+          hostPath:
+            path: /etc/hpe-storage
+        - name: root-dir
+          hostPath:
+            path: /
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30

--- a/charts/hpe-csi-driver/v1.3.1/templates/hpe-csi-node.yaml
+++ b/charts/hpe-csi-driver/v1.3.1/templates/hpe-csi-node.yaml
@@ -1,0 +1,165 @@
+---
+
+#######################################
+############  Node driver  ############
+#######################################
+
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: hpe-csi-node
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: hpe-csi-node
+  template:
+    metadata:
+      labels:
+        app: hpe-csi-node
+        role: hpe-csi
+    spec:
+      serviceAccount: hpe-csi-node-sa
+      {{- if semverCompare ">=1.17.0" .Capabilities.KubeVersion.GitVersion }}
+      priorityClassName: system-node-critical
+      {{- end }}
+      hostNetwork: true
+      dnsPolicy: ClusterFirstWithHostNet
+      dnsConfig:
+        options:
+          - name: ndots
+            value: "1"
+      containers:
+        - name: csi-node-driver-registrar
+          image: quay.io/k8scsi/csi-node-driver-registrar:v1.1.0
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+            - "--v=5"
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "rm -rf /registration/csi.hpe.com /registration/csi.hpe.com-reg.sock"]
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+            - name: DRIVER_REG_SOCK_PATH
+              value: /var/lib/kubelet/plugins/csi.hpe.com/csi.sock
+            {{- if semverCompare "~1.12.0" .Capabilities.KubeVersion.GitVersion }}
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            {{- end }}
+          imagePullPolicy: "Always"
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi/
+            - name: registration-dir
+              mountPath: /registration
+        - name: hpe-csi-driver
+          image: hpestorage/csi-driver:v1.3.0
+          args :
+            - "--endpoint=$(CSI_ENDPOINT)"
+            - "--node-service"
+            - "--flavor=kubernetes"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: LOG_LEVEL
+              value: {{ .Values.logLevel }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            {{ if and .Values.iscsi.chapUser .Values.iscsi.chapPassword }}
+            - name: CHAP_USER
+              value: {{ .Values.iscsi.chapUser }}
+            - name: CHAP_PASSWORD
+              value: {{ .Values.iscsi.chapPassword }}
+            {{- end }}
+            {{ if .Values.disableNodeConformance -}}
+            - name: DISABLE_NODE_CONFORMANCE
+              value: "true"
+            {{- end }}
+          imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+          securityContext:
+            privileged: true
+            capabilities:
+              add: ["SYS_ADMIN"]
+            allowPrivilegeEscalation: true
+          volumeMounts:
+            - name: plugin-dir
+              mountPath: /csi
+            - name: pods-mount-dir
+              mountPath: /var/lib/kubelet
+              # needed so that any mounts setup inside this container are
+              # propagated back to the host machine.
+              mountPropagation: "Bidirectional"
+            - name: root-dir
+              mountPath: /host
+              mountPropagation: "Bidirectional"
+            - name: device-dir
+              mountPath: /dev
+            - name: log-dir
+              mountPath: /var/log
+            - name: etc-hpe-storage-dir
+              mountPath: /etc/hpe-storage
+            - name: etc-kubernetes
+              mountPath: /etc/kubernetes
+            - name: sys
+              mountPath: /sys
+            - name: runsystemd
+              mountPath: /run/systemd
+            - name: etcsystemd
+              mountPath: /etc/systemd/system
+            - name: linux-config-file
+              mountPath: /opt/hpe-storage/nimbletune/config.json
+              subPath: config.json
+      volumes:
+        - name: registration-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins_registry
+        - name: plugin-dir
+          hostPath:
+            path: /var/lib/kubelet/plugins/csi.hpe.com
+        - name: pods-mount-dir
+          hostPath:
+            path: /var/lib/kubelet
+        - name: root-dir
+          hostPath:
+            path: /
+        - name: device-dir
+          hostPath:
+            path: /dev
+        - name: log-dir
+          hostPath:
+            path: /var/log
+        - name: etc-hpe-storage-dir
+          hostPath:
+            path: /etc/hpe-storage
+        - name: etc-kubernetes
+          hostPath:
+            path: /etc/kubernetes
+        - name: runsystemd
+          hostPath:
+            path: /run/systemd
+        - name: etcsystemd
+          hostPath:
+            path: /etc/systemd/system
+        - name: sys
+          hostPath:
+            path: /sys
+        - name: linux-config-file
+          configMap:
+            name: hpe-linux-config
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30

--- a/charts/hpe-csi-driver/v1.3.1/templates/hpe-csi-rbac.yaml
+++ b/charts/hpe-csi-driver/v1.3.1/templates/hpe-csi-rbac.yaml
@@ -1,0 +1,408 @@
+---
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: hpe-csi-controller-sa
+  namespace: {{ .Release.Namespace }}
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hpe-csi-provisioner-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list", "create"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts"]
+    verbs: ["get", "list", "create"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+{{- if semverCompare ">=1.17.0" .Capabilities.KubeVersion.GitVersion }}
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["get", "list"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["get", "list"]
+{{- end }}
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "delete"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch", "delete"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hpe-csi-provisioner-binding
+subjects:
+  - kind: ServiceAccount
+    name: hpe-csi-controller-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: hpe-csi-provisioner-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hpe-csi-attacher-role
+rules:
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["get", "list", "watch", "update", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "watch", "list"]
+  {{- if semverCompare "~1.12.0" .Capabilities.KubeVersion.GitVersion }}
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  {{- else if semverCompare "~1.13.0" .Capabilities.KubeVersion.GitVersion }}
+  - apiGroups: ["csi.storage.k8s.io"]
+    resources: ["csinodeinfos"]
+    verbs: ["get", "list", "watch"]
+  {{ else }}
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csinodes"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hpe-csi-attacher-binding
+subjects:
+  - kind: ServiceAccount
+    name: hpe-csi-controller-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: hpe-csi-attacher-role
+  apiGroup: rbac.authorization.k8s.io
+
+
+{{- if semverCompare ">=1.17.0" .Capabilities.KubeVersion.GitVersion }}
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hpe-csi-snapshotter-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots"]
+    verbs: ["create", "update", "delete", "get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshots/status"]
+    verbs: ["update"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents"]
+    verbs: ["create", "update", "delete", "get", "list", "watch"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotcontents/status"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["snapshot.storage.k8s.io"]
+    resources: ["volumesnapshotclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch", "create", "delete", "update"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hpe-csi-snapshotter-binding
+subjects:
+  - kind: ServiceAccount
+    name: hpe-csi-controller-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: hpe-csi-snapshotter-role
+  apiGroup: rbac.authorization.k8s.io
+
+{{- end }}
+
+
+{{- if semverCompare ">=1.15.0" .Capabilities.KubeVersion.GitVersion }}
+---
+# Resizer must be able to work with PVCs, PVs, SCs.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: external-resizer-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-role
+subjects:
+  - kind: ServiceAccount
+    name: hpe-csi-controller-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: external-resizer-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+# Resizer must be able to work with end point in current namespace
+# if (and only if) leadership election is enabled
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: external-resizer-cfg
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-resizer-role-cfg
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: hpe-csi-controller-sa
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: external-resizer-cfg
+  apiGroup: rbac.authorization.k8s.io
+
+
+---
+# mutator must be able to work with PVCs, PVs, SCs.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-mutator-role
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["update", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["list", "watch", "create", "update", "patch"]
+
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-mutator-binding
+subjects:
+  - kind: ServiceAccount
+    name: hpe-csi-controller-sa
+    # replace with non-default namespace name
+    namespace: kube-system
+roleRef:
+  kind: ClusterRole
+  name: csi-mutator-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+# mutator must be able to work with end point in current namespace
+# if (and only if) leadership election is enabled
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  namespace: kube-system
+  name: csi-mutator-cfg
+rules:
+- apiGroups: ["coordination.k8s.io"]
+  resources: ["leases"]
+  verbs: ["get", "watch", "list", "delete", "update", "create"]
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: csi-mutator-role-cfg
+  namespace: kube-system
+subjects:
+  - kind: ServiceAccount
+    name: hpe-csi-controller-sa
+    namespace: kube-system
+roleRef:
+  kind: Role
+  name: csi-mutator-cfg
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}
+
+---
+
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hpe-csi-driver-role
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: ["storage.hpe.com"]
+    resources: ["hpenodeinfos"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["storage.hpe.com"]
+    resources: ["hpevolumeinfos"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["storage.hpe.com"]
+    resources: ["hpereplicationdeviceinfos"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["services"]
+    verbs: ["get"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["get", "list"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses"]
+    verbs: ["get", "list", "watch"]
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: hpe-csi-node-sa
+  namespace: {{ .Release.Namespace }}
+
+---
+
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: hpe-csi-driver-binding
+subjects:
+  - kind: ServiceAccount
+    name: hpe-csi-controller-sa
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: hpe-csi-node-sa
+    namespace: {{ .Release.Namespace }}
+  - kind: ServiceAccount
+    name: hpe-csp-sa
+    namespace: {{ .Release.Namespace }}
+
+roleRef:
+  kind: ClusterRole
+  name: hpe-csi-driver-role
+  apiGroup: rbac.authorization.k8s.io
+
+---
+
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: hpe-csp-sa
+  namespace: {{ .Release.Namespace }}

--- a/charts/hpe-csi-driver/v1.3.1/templates/hpe-linux-config.yaml
+++ b/charts/hpe-csi-driver/v1.3.1/templates/hpe-linux-config.yaml
@@ -1,0 +1,13 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: hpe-linux-config
+  namespace: {{ .Release.Namespace }}
+data:
+{{ if and .Values.iscsi.chapUser .Values.iscsi.chapPassword }}
+  CHAP_USER: {{ .Values.iscsi.chapUser  | quote }}
+  CHAP_PASSWORD: {{ .Values.iscsi.chapPassword  | quote }}
+{{- end }}
+  config.json: |-
+{{ (.Files.Get "files/config.json") | indent 4 }}

--- a/charts/hpe-csi-driver/v1.3.1/templates/hpe-secret.yaml
+++ b/charts/hpe-csi-driver/v1.3.1/templates/hpe-secret.yaml
@@ -1,0 +1,47 @@
+{{ if $secret := (lookup "v1" "Secret" .Release.Namespace "nimble-secret") -}}
+# This is required to maintain backward compatibility of resources(secret)
+# created with previous releases as we no longer create a secret with CSI driver install.
+# Annotation "helm.sh/resource-policy": keep" should help to remove this file altogether
+# in future.
+# Also, manage the secret only if created by previous versions of helm with below check.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nimble-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+data:
+  username: {{ $secret.data.username }}
+  password: {{ $secret.data.password }}
+  servicePort: {{ $secret.data.servicePort }}
+  backend: {{ $secret.data.backend }}
+  serviceName: {{ $secret.data.serviceName }}
+{{- end }}
+
+{{ if $secret := (lookup "v1" "Secret" .Release.Namespace "primera3par-secret") -}}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: primera3par-secret
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+data:
+  username: {{ $secret.data.username }}
+  password: {{ $secret.data.password }}
+  servicePort: {{ $secret.data.servicePort }}
+  backend: {{ $secret.data.backend }}
+  serviceName: {{ $secret.data.serviceName }}
+{{- end }}
+

--- a/charts/hpe-csi-driver/v1.3.1/templates/nimble-csp.yaml
+++ b/charts/hpe-csi-driver/v1.3.1/templates/nimble-csp.yaml
@@ -1,0 +1,60 @@
+---
+### CSP Service ###
+kind: Service
+apiVersion: v1
+metadata:
+  name: nimble-csp-svc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: nimble-csp-svc
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+  selector:
+    app: nimble-csp
+
+---
+### CSP deployment ###
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: nimble-csp
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: nimble-csp
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nimble-csp
+    spec:
+      serviceAccount: hpe-csp-sa
+      {{- if semverCompare ">=1.17.0" .Capabilities.KubeVersion.GitVersion }}
+      priorityClassName: system-cluster-critical
+      {{- end }}
+      containers:
+        - name: nimble-csp
+          image: hpestorage/nimble-csp:v1.3.0
+          imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: log-dir
+              mountPath: /var/log
+      volumes:
+        - name: log-dir
+          hostPath:
+            path: /var/log
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30
+

--- a/charts/hpe-csi-driver/v1.3.1/templates/primera-3par-csp.yaml
+++ b/charts/hpe-csi-driver/v1.3.1/templates/primera-3par-csp.yaml
@@ -1,0 +1,61 @@
+---
+### CSP Service ###
+kind: Service
+apiVersion: v1
+metadata:
+  name: primera3par-csp-svc
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: primera3par-csp-svc
+spec:
+  ports:
+  - port: 8080
+    protocol: TCP
+  selector:
+    app: primera3par-csp
+
+---
+### CSP deployment ###
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: primera3par-csp
+  labels:
+    app: primera3par-csp
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: primera3par-csp
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: primera3par-csp
+    spec:
+      serviceAccount: hpe-csp-sa
+      {{- if semverCompare ">=1.17.0" .Capabilities.KubeVersion.GitVersion }}
+      priorityClassName: system-cluster-critical
+      {{- end }}
+      containers:
+        - name: primera3par-csp
+          image: hpestorage/hpe3parprimera-csp:v1.1.0
+          imagePullPolicy: {{ .Values.imagePullPolicy | quote }}
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: log-dir
+              mountPath: /var/log
+      volumes:
+        - name: log-dir
+          hostPath:
+            path: /var/log
+      tolerations:
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+          tolerationSeconds: 30
+        - effect: NoExecute
+          key: node.kubernetes.io/unreachable
+          operator: Exists
+          tolerationSeconds: 30

--- a/charts/hpe-csi-driver/v1.3.1/templates/sc.yaml
+++ b/charts/hpe-csi-driver/v1.3.1/templates/sc.yaml
@@ -1,0 +1,38 @@
+{{ if $sc := (lookup "storage.k8s.io/v1" "StorageClass" "" "hpe-standard") -}}
+# This is required to maintain backward compatibility of resources(storageclass)
+# created with previous releases as we no longer create a storageclass with CSI driver install.
+# Annotation "helm.sh/resource-policy": keep" should help to remove this file altogether
+# in future.
+# Also, manage the storageClass only if created by previous versions of helm with below check.
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: hpe-standard
+  labels:
+    plugin: {{ $.Release.Name }}
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    helm.sh/resource-policy: keep
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
+    {{- range $k, $v := $sc.metadata.annotations }}
+    {{- if or (eq $v "true") (eq $v "false")}}
+    {{ $k }}: {{ $v | quote }}
+    {{- else }}
+    {{ $k }}: {{ $v }}
+    {{- end }}
+    {{- end }}
+provisioner: csi.hpe.com
+{{- if semverCompare ">=1.15.0" .Capabilities.KubeVersion.GitVersion }}
+allowVolumeExpansion: {{ $sc.allowVolumeExpansion }}
+{{- end }}
+parameters:
+  {{- range $k, $v := $sc.parameters }}
+  {{- if or (eq $v "true") (eq $v "false")}}
+  {{ $k }}: {{ $v | quote }}
+  {{- else }}
+  {{ $k }}: {{ $v }}
+  {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/hpe-csi-driver/v1.3.1/values.yaml
+++ b/charts/hpe-csi-driver/v1.3.1/values.yaml
@@ -1,0 +1,20 @@
+# Default values for hpe-csi-storage.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# image pull policy for all images in csi deployment
+imagePullPolicy: 'IfNotPresent'
+
+# flavor
+flavor: kubernetes
+
+# log level for all csi driver components
+logLevel: info
+
+## For controlling automatic iscsi/multipath package installation (default: false)
+disableNodeConformance: false
+
+# values for CHAP Authentication
+iscsi:
+  chapUser: ""
+  chapPassword: ""


### PR DESCRIPTION
Issues where reported from FC customers that iSCSI CHAP was mandatory. 

```
$ diff -r v1.3.0/ v1.3.1/
diff -r v1.3.0/Chart.yaml v1.3.1/Chart.yaml
12c12
< version: 1.3.0
---
> version: 1.3.1
diff -r v1.3.0/questions.yml v1.3.1/questions.yml
25c25
<   required: true
---
>   required: false
31c31
<   required: true
---
>   required: false
```

Signed-off-by: Michael Mattsson <michael.mattsson@nimblestorage.com>