### PR TITLE
Add vsphere CPI and CSI charts

### DIFF
--- a/charts/vsphere-cpi/taints.sh
+++ b/charts/vsphere-cpi/taints.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+export KUBECONFIG=$1
+for node in $(kubectl get nodes | awk '{print $1}' | tail -n +2)
+do
+	kubectl taint node $node node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
+done

--- a/charts/vsphere-cpi/v1.0.0/Chart.yaml
+++ b/charts/vsphere-cpi/v1.0.0/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: vsphere-cpi
+version: 1.0.0
+appVersion: 1.0.0
+description: vSphere CPI driver
+sources:
+  - https://github.com/kubernetes/cloud-provider-vsphere
+maintainers:
+  - name: Rancher
+    email: rajashree.28m@gmail.com

--- a/charts/vsphere-cpi/v1.0.0/Chart.yaml
+++ b/charts/vsphere-cpi/v1.0.0/Chart.yaml
@@ -7,4 +7,4 @@ sources:
   - https://github.com/kubernetes/cloud-provider-vsphere
 maintainers:
   - name: Rancher
-    email: rajashree.28m@gmail.com
+    email: caleb@rancher.com

--- a/charts/vsphere-cpi/v1.0.0/app-readme.md
+++ b/charts/vsphere-cpi/v1.0.0/app-readme.md
@@ -1,0 +1,14 @@
+vSphere Cloud Provider Interface (CPI)
+
+1. This chart deploys manifests from the [kubernetes/cloud-provider-vsphere](https://github.com/kubernetes/cloud-provider-vsphere) repository, following the steps mentioned in [this](https://vsphere-csi-driver.sigs.k8s.io/driver-deployment/prerequisites.html#vsphere_cpi) tutorial.
+2. As mentioned in the tutorial, the CPI requires the vsphere cloud-config to be provided via a ConfigMap. It also requires the vSphere credentials to be provided via a Secret, which is then referred by the ConfigMap.
+This chart provides manifests to create the Secret and the ConfigMap.
+3. When this chart is used for migrating volumes provisioned using the in-tree provider to the out-of-tree CPI+CSI, all nodes need to be tainted with the following taint:
+```
+node.cloudprovider.kubernetes.io/uninitialized=true:NoSchedule
+```
+The script [taints.sh](../taints.sh) can be run for tainting the nodes using the following command:
+```
+taints.sh <path_to_kubeconfig (optional, if running outside the cluster)>
+```
+4. You can also modify the nodeSelectors for the CPI cloud-controller-manager by providing the required selector in values.yaml

--- a/charts/vsphere-cpi/v1.0.0/questions.yaml
+++ b/charts/vsphere-cpi/v1.0.0/questions.yaml
@@ -1,0 +1,25 @@
+questions: 
+- variable: vCenter.host
+  label: vCenter Host
+  description: Set the vCenter IP address / FQDN
+  type: string
+  required: true
+  group: Configuration
+- variable: vCenter.datacenters
+  description: Comma-separated list of Datacenter paths
+  label: Data Centers
+  type: string
+  required: true
+  group: Configuration
+- variable: vCenter.username
+  label: Username
+  description: Username for vCenter
+  type: string
+  required: true
+  group: Configuration
+- variable: vCenter.password
+  label: Password
+  description: Password for vCenter
+  type: password
+  required: true
+  group: Configuration

--- a/charts/vsphere-cpi/v1.0.0/templates/vsphere-cloud-config-cm.yaml
+++ b/charts/vsphere-cpi/v1.0.0/templates/vsphere-cloud-config-cm.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloud-config
+  namespace: {{ .Release.Namespace }}
+data:
+  vsphere.conf: |
+    [Global]
+    secret-name = "vsphere-cpi-creds"
+    secret-namespace = {{ .Release.Namespace | quote }}
+    port = {{ .Values.vCenter.port | default "443" | quote }}
+    insecure-flag = {{ .Values.vCenter.insecureflag | default "1" | quote }}
+
+    [VirtualCenter {{ .Values.vCenter.host | quote }}]
+    datacenters = {{ .Values.vCenter.datacenters | quote }}
+

--- a/charts/vsphere-cpi/v1.0.0/templates/vsphere-cpi-ds.yaml
+++ b/charts/vsphere-cpi/v1.0.0/templates/vsphere-cpi-ds.yaml
@@ -1,0 +1,74 @@
+# Source: https://github.com/kubernetes/cloud-provider-vsphere/blob/master/releases/v1.19/vsphere-cloud-controller-manager.yaml
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  annotations:
+    scheduler.alpha.kubernetes.io/critical-pod: ""
+  labels:
+    component: cloud-controller-manager
+    tier: control-plane
+    k8s-app: vsphere-cloud-controller-manager
+  name: vsphere-cloud-controller-manager
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      k8s-app: vsphere-cloud-controller-manager
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        k8s-app: vsphere-cloud-controller-manager
+    spec:
+      nodeSelector:
+      {{- if .Values.nodeSelector}}
+      {{- with .Values.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- else }}
+        node-role.kubernetes.io/controlplane: "true"
+      {{- end }}
+      securityContext:
+        runAsUser: 1001
+      tolerations:
+      - effect: NoExecute
+        operator: Exists
+      - effect: NoSchedule
+        operator: Exists
+      serviceAccountName: cloud-controller-manager
+      containers:
+        - name: vsphere-cloud-controller-manager
+          image: gcr.io/cloud-provider-vsphere/cpi/release/manager:v1.2.1
+          args:
+            - --v=2
+            - --cloud-provider=vsphere
+            - --cloud-config=/etc/cloud/vsphere.conf
+          volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+          resources:
+            requests:
+              cpu: 200m
+      hostNetwork: true
+      volumes:
+      - name: vsphere-config-volume
+        configMap:
+          name: cloud-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    component: cloud-controller-manager
+  name: vsphere-cloud-controller-manager
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: NodePort
+  ports:
+    - port: 43001
+      protocol: TCP
+      targetPort: 43001
+  selector:
+    component: cloud-controller-manager

--- a/charts/vsphere-cpi/v1.0.0/templates/vsphere-cpi-rbac.yaml
+++ b/charts/vsphere-cpi/v1.0.0/templates/vsphere-cpi-rbac.yaml
@@ -1,0 +1,127 @@
+# Source: https://github.com/kubernetes/cloud-provider-vsphere/blob/master/releases/v1.19/vsphere-cloud-controller-manager.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-controller-manager
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloud-controller-manager
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - nodes/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services/status
+  verbs:
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumes
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - "coordination.k8s.io"
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: apiserver-authentication-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- apiGroup: ""
+  kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: {{ .Release.Namespace }}
+- apiGroup: ""
+  kind: User
+  name: cloud-controller-manager
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cloud-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cloud-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: cloud-controller-manager
+  namespace: {{ .Release.Namespace }}
+- kind: User
+  name: cloud-controller-manager

--- a/charts/vsphere-cpi/v1.0.0/templates/vsphere-creds-secret.yaml
+++ b/charts/vsphere-cpi/v1.0.0/templates/vsphere-creds-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-cpi-creds
+  namespace: {{ .Release.Namespace }}
+stringData:
+  {{ .Values.vCenter.host }}.username: {{ .Values.vCenter.username }}
+  {{ .Values.vCenter.host }}.password: {{ .Values.vCenter.password }}

--- a/charts/vsphere-cpi/v1.0.0/values.yaml
+++ b/charts/vsphere-cpi/v1.0.0/values.yaml
@@ -1,0 +1,9 @@
+vCenter:
+  host: ""
+  insecureflag: "1"
+  port: "443"
+  datacenters: ""
+  username: ""
+  password: ""
+
+nodeSelector: {}

--- a/charts/vsphere-csi/v2.1.0/Chart.yaml
+++ b/charts/vsphere-csi/v2.1.0/Chart.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+name: vsphere-csi
+version: 2.1.0
+appVersion: 2.1.0
+description: vSphere CSI driver
+sources:
+  - https://github.com/kubernetes-sigs/vsphere-csi-driver
+maintainers:
+  - name: Rancher
+    email: caleb@rancher.com

--- a/charts/vsphere-csi/v2.1.0/app-readme.md
+++ b/charts/vsphere-csi/v2.1.0/app-readme.md
@@ -1,0 +1,6 @@
+vSphere Cloud Storage Interface (CSI)
+
+1. This chart deploys manifests from the [kubernetes-sigs/vsphere-csi-driver](https://github.com/kubernetes-sigs/vsphere-csi-driver/tree/release-2.1/manifests/v2.1.0/vsphere-7.0u1/vanilla ) repository, following the steps mentioned in [this](https://vsphere-csi-driver.sigs.k8s.io/features/vsphere_csi_migration.html) tutorial.
+2. As mentioned in the tutorial, the CSI requires the vsphere cloud-config to be provided via a Secret. This chart contains a manifest that can be used to create this Secret by providing the required values through values.yaml
+3. It also provides the option of creating a StorageClass that uses the `csi.vsphere.vmware.com` as provsioner.
+4. You can also modify the nodeSelectors for the CSI controller by providing the required selector in values.yaml

--- a/charts/vsphere-csi/v2.1.0/questions.yaml
+++ b/charts/vsphere-csi/v2.1.0/questions.yaml
@@ -1,0 +1,59 @@
+questions: 
+- variable: vCenter.host
+  label: vCenter Host
+  description: Set the vCenter IP address / FQDN
+  type: string
+  required: true
+  group: Configuration
+- variable: vCenter.datacenter
+  description: Comma-separated list of Datacenter paths
+  label: Data Center
+  type: string
+  required: true
+  group: Configuration
+- variable: vCenter.username
+  label: Username
+  description: Username for vCenter
+  type: string
+  required: true
+  group: Configuration
+- variable: vCenter.password
+  label: Password
+  description: Password for vCenter
+  type: password
+  required: true
+  group: Configuration
+- variable: csiMigration
+  label: Enable CSI Migration
+  description: Select this to migrate volumes provisioned by in-tree vSphere provider to CSI
+  type: boolean
+  default: false
+- variable: storageClass.enable
+  default: true
+  label: Create a storageClass with the vSphere CSI provisioner
+  type: boolean
+  show_subquestion_if: true
+  group: "storageClass"
+  subquestions:
+    - variable: storageClass.name
+      label: Name of the storageClass
+      default: "vsphere-csi-sc"
+      type: string
+      required: true
+    - variable: storageClass.default
+      label: Set this as the default storageClass
+      default: "true"
+      type: boolean
+      required: true
+      group: "storageClass"
+    - variable: storageclass.storagePolicyname
+      label: Name of the Storage Policy created in vcenter
+      default: ""
+      type: string
+      required: false
+      group: "storageClass"
+    - variable: storageClass.datastoreURL
+      label: Provide the URL of the datastore to create volumes in, if not specified, any datastore that matches the request will be selected
+      type: "string"
+      required: false
+      group: "storageClass"

--- a/charts/vsphere-csi/v2.1.0/templates/vsphere-csi-controller-deployment.yaml
+++ b/charts/vsphere-csi/v2.1.0/templates/vsphere-csi-controller-deployment.yaml
@@ -1,0 +1,175 @@
+# Source: https://github.com/kubernetes-sigs/vsphere-csi-driver
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: vsphere-csi-controller
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-controller
+        role: vsphere-csi
+    spec:
+      serviceAccountName: vsphere-csi-controller
+      nodeSelector:
+      {{- if .Values.nodeSelector}}
+      {{- with .Values.nodeSelector }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- else }}
+        node-role.kubernetes.io/controlplane: "true"
+      {{- end }}
+      tolerations:
+        - operator: "Exists"
+          effect: NoSchedule
+        - operator: "Exists"
+          effect: NoExecute
+      dnsPolicy: "Default"
+      containers:
+        - name: csi-attacher
+          image: quay.io/k8scsi/csi-attacher:v3.0.0
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: csi-resizer
+          image: quay.io/k8scsi/csi-resizer:v1.0.0
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+        - name: vsphere-csi-controller
+          image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0
+          args:
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+          imagePullPolicy: "Always"
+          env:
+            - name: CSI_ENDPOINT
+              value: unix:///csi/csi.sock
+            - name: X_CSI_MODE
+              value: "controller"
+            - name: VSPHERE_CSI_CONFIG
+              value: "/etc/cloud/csi-vsphere.conf"
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+            - mountPath: /csi
+              name: socket-dir
+          ports:
+            - name: healthz
+              containerPort: 9808
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 5
+            failureThreshold: 3
+        - name: liveness-probe
+          image: quay.io/k8scsi/livenessprobe:v2.1.0
+          args:
+            - "--v=4"
+            - "--csi-address=/csi/csi.sock"
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+        - name: vsphere-syncer
+          image: gcr.io/cloud-provider-vsphere/csi/release/syncer:v2.1.0
+          args:
+            - "--leader-election"
+            - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+            - "--fss-namespace=$(CSI_NAMESPACE)"
+          imagePullPolicy: "Always"
+          env:
+            - name: FULL_SYNC_INTERVAL_MINUTES
+              value: "30"
+            - name: VSPHERE_CSI_CONFIG
+              value: "/etc/cloud/csi-vsphere.conf"
+            - name: LOGGER_LEVEL
+              value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+            - name: INCLUSTER_CLIENT_QPS
+              value: "100"
+            - name: INCLUSTER_CLIENT_BURST
+              value: "100"
+            - name: CSI_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - mountPath: /etc/cloud
+              name: vsphere-config-volume
+              readOnly: true
+        - name: csi-provisioner
+          image: quay.io/k8scsi/csi-provisioner:v2.0.0
+          args:
+            - "--v=4"
+            - "--timeout=300s"
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election"
+            - "--default-fstype=ext4"
+            # needed only for topology aware setup
+            #- "--feature-gates=Topology=true"
+            #- "--strict-topology"
+          env:
+            - name: ADDRESS
+              value: /csi/csi.sock
+          volumeMounts:
+            - mountPath: /csi
+              name: socket-dir
+      volumes:
+      - name: vsphere-config-volume
+        secret:
+          secretName: vsphere-config-secret
+      - name: socket-dir
+        emptyDir: {}
+---
+apiVersion: v1
+data:
+  "csi-migration": {{ .Values.csiMigration | quote }} # csi-migration feature is only available for vSphere 7.0U1
+kind: ConfigMap
+metadata:
+  name: internal-feature-states.csi.vsphere.vmware.com
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: storage.k8s.io/v1 # For k8s 1.17 or lower use storage.k8s.io/v1beta1
+kind: CSIDriver
+metadata:
+  name: csi.vsphere.vmware.com
+spec:
+  attachRequired: true
+  podInfoOnMount: false
+---
+

--- a/charts/vsphere-csi/v2.1.0/templates/vsphere-csi-controller-rbac.yaml
+++ b/charts/vsphere-csi/v2.1.0/templates/vsphere-csi-controller-rbac.yaml
@@ -1,0 +1,55 @@
+# Source: https://github.com/kubernetes-sigs/vsphere-csi-driver
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: vsphere-csi-controller
+  namespace: {{ .Release.Namespace }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-role
+rules:
+  - apiGroups: [""]
+    resources: ["nodes", "persistentvolumeclaims", "pods", "configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumeclaims/status"]
+    verbs: ["patch"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch", "create", "update", "delete", "patch"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "list", "delete", "update", "create"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["storageclasses", "csinodes"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["cns.vmware.com"]
+    resources: ["cnsvspherevolumemigrations"]
+    verbs: ["create", "get", "list", "watch", "update", "delete"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "create"]
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["volumeattachments/status"]
+    verbs: ["patch"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: vsphere-csi-controller-binding
+subjects:
+  - kind: ServiceAccount
+    name: vsphere-csi-controller
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: vsphere-csi-controller-role
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/vsphere-csi/v2.1.0/templates/vsphere-csi-node-ds.yaml
+++ b/charts/vsphere-csi/v2.1.0/templates/vsphere-csi-node-ds.yaml
@@ -1,0 +1,139 @@
+# Source: https://github.com/kubernetes-sigs/vsphere-csi-driver
+kind: DaemonSet
+apiVersion: apps/v1
+metadata:
+  name: vsphere-csi-node
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+    matchLabels:
+      app: vsphere-csi-node
+  updateStrategy:
+    type: "RollingUpdate"
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app: vsphere-csi-node
+        role: vsphere-csi
+    spec:
+      dnsPolicy: "Default"
+      containers:
+      - name: node-driver-registrar
+        image: quay.io/k8scsi/csi-node-driver-registrar:v2.0.1
+        args:
+        - "--v=5"
+        - "--csi-address=$(ADDRESS)"
+        - "--kubelet-registration-path=$(DRIVER_REG_SOCK_PATH)"
+        - "--health-port=9809"
+        env:
+        - name: ADDRESS
+          value: /csi/csi.sock
+        - name: DRIVER_REG_SOCK_PATH
+          value: /var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi
+        - name: registration-dir
+          mountPath: /registration
+        ports:
+        - containerPort: 9809
+          name: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
+      - name: vsphere-csi-node
+        image: gcr.io/cloud-provider-vsphere/csi/release/driver:v2.1.0
+        args:
+          - "--fss-name=internal-feature-states.csi.vsphere.vmware.com"
+          - "--fss-namespace=$(CSI_NAMESPACE)"
+        imagePullPolicy: "Always"
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: CSI_ENDPOINT
+          value: unix:///csi/csi.sock
+        - name: X_CSI_MODE
+          value: "node"
+        - name: X_CSI_SPEC_REQ_VALIDATION
+          value: "false"
+        # needed only for topology aware setups
+        #- name: VSPHERE_CSI_CONFIG
+        #  value: "/etc/cloud/csi-vsphere.conf" # here csi-vsphere.conf is the name of the file used for creating secret using "--from-file" flag
+        - name: X_CSI_DEBUG
+          value: "true"
+        - name: LOGGER_LEVEL
+          value: "PRODUCTION" # Options: DEVELOPMENT, PRODUCTION
+        - name: CSI_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["SYS_ADMIN"]
+          allowPrivilegeEscalation: true
+        volumeMounts:
+        # needed only for topology aware setups
+        #- name: vsphere-config-volume
+        #  mountPath: /etc/cloud
+        #  readOnly: true
+        - name: plugin-dir
+          mountPath: /csi
+        - name: pods-mount-dir
+          mountPath: /var/lib/kubelet
+          # needed so that any mounts setup inside this container are
+          # propagated back to the host machine.
+          mountPropagation: "Bidirectional"
+        - name: device-dir
+          mountPath: /dev
+        ports:
+          - containerPort: 9808
+            name: healthz
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+      - name: liveness-probe
+        image: quay.io/k8scsi/livenessprobe:v2.1.0
+        args:
+          - "--v=4"
+          - "--csi-address=/csi/csi.sock"
+        volumeMounts:
+        - name: plugin-dir
+          mountPath: /csi
+      volumes:
+      # needed only for topology aware setups
+      #- name: vsphere-config-volume
+      #  secret:
+      #    secretName: vsphere-config-secret
+      - name: registration-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins_registry
+          type: Directory
+      - name: plugin-dir
+        hostPath:
+          path: /var/lib/kubelet/plugins/csi.vsphere.vmware.com
+          type: DirectoryOrCreate
+      - name: pods-mount-dir
+        hostPath:
+          path: /var/lib/kubelet
+          type: Directory
+      - name: device-dir
+        hostPath:
+          path: /dev
+      tolerations:
+        - effect: NoExecute
+          operator: Exists
+        - effect: NoSchedule
+          operator: Exists

--- a/charts/vsphere-csi/v2.1.0/templates/vsphere-csi-secret.yaml
+++ b/charts/vsphere-csi/v2.1.0/templates/vsphere-csi-secret.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vsphere-config-secret
+  namespace: {{ .Release.Namespace }}
+stringData:
+  csi-vsphere.conf: |
+    [Global]
+    cluster-id = {{ uuidv4 }}
+    user = {{ .Values.vCenter.username | quote }}
+    password = {{ .Values.vCenter.password | quote }}
+    port = {{ .Values.vCenter.port | default "443" | quote }}
+    insecure-flag = {{ .Values.vCenter.insecureflag | default "1" | quote }}
+
+    [VirtualCenter {{ .Values.vCenter.host | quote }}]
+    datacenters = {{ .Values.vCenter.datacenters | quote }}
+
+    [Workspace]
+    server = {{ .Values.vCenter.host | quote }}
+    datacenter = {{ .Values.vCenter.datacenter | quote }}
+    default-datastore = {{ .Values.vCenter.defaultDatastore | quote }}

--- a/charts/vsphere-csi/v2.1.0/templates/vsphere-csi-storageclass.yaml
+++ b/charts/vsphere-csi/v2.1.0/templates/vsphere-csi-storageclass.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.storageClass.enable }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+ name: {{ .Values.storageClass.name | default "vsphere-csi-sc" | quote }}
+ annotations:
+  storageclass.kubernetes.io/is-default-class: {{ .Values.storageClass.isDefault | quote }}
+provisioner: csi.vsphere.vmware.com
+parameters:
+  {{- if .Values.storageClass.datastoreURL  }}
+  datastoreURL: {{ .Values.storageClass.datastoreURL | quote }}
+  {{- end }}
+  {{- if .Values.storageClass.storagePolicyname }}
+  storagepolicyname: {{ .Values.storageClass.storagePolicyname | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/vsphere-csi/v2.1.0/values.yaml
+++ b/charts/vsphere-csi/v2.1.0/values.yaml
@@ -1,0 +1,17 @@
+vCenter:
+  host: ""
+  insecureflag: "1"
+  port: "443"
+  datacenters: ""
+  username: ""
+  password: ""
+
+csiMigration: ""
+
+storageClass:
+  enable: "true"
+  name: ""
+  isDefault: ""
+  storagePolicyName: ""
+
+nodeSelector: {}


### PR DESCRIPTION
This PR adds charts for the vSphere Cloud Provider plugin and Cloud Storage Interface.
Most of the manifests are from the upstream repositories, and I've mentioned them in the Chart.yaml's sources section as per https://helm.sh/docs/topics/charts/#the-chartyaml-file

Some of the changes in these manifests include accepting nodeSelector from values.yaml, so that these charts can be used for RKE2 as well. If no nodeSelector is provided through values.yaml then the default one for RKE is used.
An addition to the manifests from upstream repositories are the manifests to create the secrets and configmaps required by CPI+CSI. These charts create the secrets/configmaps accepting values from values.yaml

The script taints.sh is needed to taint all nodes before installing CPI in the migration use case, where a cluster provisioned using the in-tree provider is migrated to using the CSI driver. The docs will contain steps on how to use it.

Here are the docs for reference: https://github.com/rancher/docs/pull/3000